### PR TITLE
Update create_or_update(): validate before save

### DIFF
--- a/bx_py_utils/__init__.py
+++ b/bx_py_utils/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '8'
+__version__ = '9'

--- a/bx_py_utils/models/manipulate.py
+++ b/bx_py_utils/models/manipulate.py
@@ -12,11 +12,14 @@ def create_or_update(*, ModelClass, lookup, **values):
 
      * Use update_fields and save only changed fields
      * return the information about changed field names.
+     * validate before save
     """
     assert isinstance(lookup, dict)
     instance = ModelClass.objects.filter(**lookup).first()
     if not instance:
-        instance = ModelClass.objects.create(**lookup, **values)
+        instance = ModelClass(**lookup, **values)
+        instance.full_clean(validate_unique=False)  # Don't create non-valid instances
+        instance.save()
         return instance, True, None
 
     updated_fields = []
@@ -26,6 +29,7 @@ def create_or_update(*, ModelClass, lookup, **values):
             updated_fields.append(key)
 
     if updated_fields:
+        instance.full_clean(validate_unique=False)  # Don't save new non-valid values
         instance.save(update_fields=updated_fields)
 
     return instance, False, updated_fields

--- a/bx_py_utils_tests/tests/test_model_manipulate.py
+++ b/bx_py_utils_tests/tests/test_model_manipulate.py
@@ -1,11 +1,13 @@
 from unittest import mock
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
 from bx_py_utils.models.manipulate import create_or_update
-from bx_py_utils_tests.test_app.models import CreateOrUpdateTestModel
 from bx_py_utils.test_utils.datetime import MockDatetimeGenerator, parse_dt
+from bx_py_utils.test_utils.model_clean_assert import AssertModelCleanCalled
+from bx_py_utils_tests.test_app.models import CreateOrUpdateTestModel
 
 
 class ModelManipulateTestCase(TestCase):
@@ -14,54 +16,60 @@ class ModelManipulateTestCase(TestCase):
 
         # create a new entry:
 
-        instance, created, updated_fields = create_or_update(
-            ModelClass=CreateOrUpdateTestModel,
-            lookup={'id': 1},
-            name='First entry',
-            slug='first'
-        )
-        assert isinstance(instance, CreateOrUpdateTestModel)
-        assert instance.id == 1
-        assert instance.name == 'First entry'
-        assert instance.slug == 'first'
-        assert instance.create_dt == parse_dt('2001-01-01T00:00:00+0000')
-        assert instance.update_dt == parse_dt('2001-01-01T00:00:00+0000')
-        assert created is True
-        assert updated_fields is None
+        with AssertModelCleanCalled() as cm:
+            instance, created, updated_fields = create_or_update(
+                ModelClass=CreateOrUpdateTestModel,
+                lookup={'id': 1},
+                name='First entry',
+                slug='first'
+            )
+            assert isinstance(instance, CreateOrUpdateTestModel)
+            assert instance.id == 1
+            assert instance.name == 'First entry'
+            assert instance.slug == 'first'
+            assert instance.create_dt == parse_dt('2001-01-01T00:00:00+0000')
+            assert instance.update_dt == parse_dt('2001-01-01T00:00:00+0000')
+            assert created is True
+            assert updated_fields is None
+        cm.assert_no_missing_cleans()
 
         # Change only 'slug'
 
-        instance, created, updated_fields = create_or_update(
-            ModelClass=CreateOrUpdateTestModel,
-            lookup={'id': 1},
-            name='First entry',
-            slug='change-value'
-        )
-        assert isinstance(instance, CreateOrUpdateTestModel)
-        assert instance.id == 1
-        assert instance.name == 'First entry'
-        assert instance.slug == 'change-value'
-        assert instance.create_dt == parse_dt('2001-01-01T00:00:00+0000')  # not changed!
-        assert instance.update_dt == parse_dt('2002-01-01T00:00:00+0000')
-        assert created is False
-        assert updated_fields == ['slug']
+        with AssertModelCleanCalled() as cm:
+            instance, created, updated_fields = create_or_update(
+                ModelClass=CreateOrUpdateTestModel,
+                lookup={'id': 1},
+                name='First entry',
+                slug='change-value'
+            )
+            assert isinstance(instance, CreateOrUpdateTestModel)
+            assert instance.id == 1
+            assert instance.name == 'First entry'
+            assert instance.slug == 'change-value'
+            assert instance.create_dt == parse_dt('2001-01-01T00:00:00+0000')  # not changed!
+            assert instance.update_dt == parse_dt('2002-01-01T00:00:00+0000')
+            assert created is False
+            assert updated_fields == ['slug']
+        cm.assert_no_missing_cleans()
 
         # Change 'name' and 'slug':
 
-        instance, created, updated_fields = create_or_update(
-            ModelClass=CreateOrUpdateTestModel,
-            lookup={'id': 1},
-            name='New name !',
-            slug='new-slug'
-        )
-        assert isinstance(instance, CreateOrUpdateTestModel)
-        assert instance.id == 1
-        assert instance.name == 'New name !'
-        assert instance.slug == 'new-slug'
-        assert instance.create_dt == parse_dt('2001-01-01T00:00:00+0000')  # not changed!
-        assert instance.update_dt == parse_dt('2003-01-01T00:00:00+0000')
-        assert created is False
-        assert updated_fields == ['name', 'slug']
+        with AssertModelCleanCalled() as cm:
+            instance, created, updated_fields = create_or_update(
+                ModelClass=CreateOrUpdateTestModel,
+                lookup={'id': 1},
+                name='New name !',
+                slug='new-slug'
+            )
+            assert isinstance(instance, CreateOrUpdateTestModel)
+            assert instance.id == 1
+            assert instance.name == 'New name !'
+            assert instance.slug == 'new-slug'
+            assert instance.create_dt == parse_dt('2001-01-01T00:00:00+0000')  # not changed!
+            assert instance.update_dt == parse_dt('2003-01-01T00:00:00+0000')
+            assert created is False
+            assert updated_fields == ['name', 'slug']
+        cm.assert_no_missing_cleans()
 
         # Nothing changed:
 
@@ -79,3 +87,27 @@ class ModelManipulateTestCase(TestCase):
         assert instance.update_dt == parse_dt('2003-01-01T00:00:00+0000')  # not changed!
         assert created is False
         assert updated_fields == []
+
+    def test_non_valid(self):
+        msg = (
+            "{'slug': ['Enter a valid “slug” consisting of letters,"
+            " numbers, underscores or hyphens.']}"
+        )
+        with self.assertRaisesMessage(ValidationError, msg):
+            create_or_update(
+                ModelClass=CreateOrUpdateTestModel,
+                lookup={'id': 1},
+                name='foo',
+                slug='this is no Slug !'
+            )
+
+        # Update existing entry with non-valid values should also not work:
+
+        CreateOrUpdateTestModel(id=1, name='foo', slug='bar')
+        with self.assertRaisesMessage(ValidationError, msg):
+            create_or_update(
+                ModelClass=CreateOrUpdateTestModel,
+                lookup={'id': 1},
+                name='foo',
+                slug='this is no Slug !'
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'bx_py_utils'
-version = "8"
+version = "9"
 description = 'Various Python / Django utility functions'
 authors = [
     'Jens Diemer <jens.diemer@boxine.de>',


### PR DESCRIPTION
It should be not possible to create or update model instance with non-valid data.
So we just call `instance.full_clean(validate_unique=False)` before save call.