### PR TITLE
+ assert_text_snapshot

### DIFF
--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -9,6 +9,23 @@ def _write_json(obj, snapshot_file):
         json.dump(obj, snapshot_handle, ensure_ascii=False, indent=4, sort_keys=True)
 
 
+def assert_text_snapshot(root_dir: Union[pathlib.Path, str], snapshot_name: str, got: str):
+    assert re.match(r'^[-_.a-zA-Z0-9]+$', snapshot_name), f'Invalid snapshot name {snapshot_name}'
+    assert isinstance(got, str)
+
+    snapshot_file = pathlib.Path(root_dir) / f'{snapshot_name}.snapshot.txt'
+    try:
+        expected = snapshot_file.read_text()
+    except (FileNotFoundError, IOError, OSError):
+        snapshot_file.write_text(got)
+        raise
+
+    if got != expected:
+        snapshot_file.write_text(got)
+
+        assert got == expected
+
+
 def assert_snapshot(root_dir: Union[pathlib.Path, str], snapshot_name: str, got: Union[dict, list]):
     assert re.match(r'^[-_.a-zA-Z0-9]+$', snapshot_name), f'Invalid snapshot name {snapshot_name}'
     assert isinstance(got, (dict, list))

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -3,7 +3,7 @@ import tempfile
 
 import pytest
 
-from bx_py_utils.test_utils.snapshot import assert_snapshot
+from bx_py_utils.test_utils.snapshot import assert_snapshot, assert_text_snapshot
 
 
 def test_assert_snapshot():
@@ -18,3 +18,21 @@ def test_assert_snapshot():
 
         with pytest.raises(AssertionError):
             assert_snapshot(tmp_dir, 'snap', [{'foo': 42, 'bär': 23}])
+
+
+def test_assert_text_snapshot():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        TEXT = 'this is\nmultiline "text"'
+        with pytest.raises(FileNotFoundError) as excinfo:
+            assert_text_snapshot(tmp_dir, 'text', TEXT)
+        written_text = (pathlib.Path(tmp_dir) / 'text.snapshot.txt').read_text()
+        assert written_text == TEXT
+
+        assert_text_snapshot(tmp_dir, 'text', TEXT)
+
+        with pytest.raises(AssertionError):
+            assert_text_snapshot(tmp_dir, 'text', 'changed')
+        written_text = (pathlib.Path(tmp_dir) / 'text.snapshot.txt').read_text()
+        assert written_text == 'changed'
+
+        assert_text_snapshot(tmp_dir, 'text', 'changed')


### PR DESCRIPTION
Sometimes, we want to compare a huge text string. `assert_snapshot` would require us to json-encode this.

Add a new variant `assert_text_snapshot` for this use case.
