### PR TITLE
Remove flaky tests

### DIFF
--- a/bx_py_utils_tests/tests/test_approve_workflow.py
+++ b/bx_py_utils_tests/tests/test_approve_workflow.py
@@ -308,7 +308,6 @@ class BaseApproveModelAdminTestCase(HtmlAssertionMixin, TestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         self.assert_html_parts(response, parts=(
-            '<title>Change approve test model | Django site admin</title>',
             '<input type="submit" value="Save and Approve" name="_approve" class="extra_submit">',
             'value="v1"',
             'value="relation one v1"',
@@ -371,7 +370,6 @@ class BaseApproveModelAdminTestCase(HtmlAssertionMixin, TestCase):
             },
         )
         self.assert_html_parts(response, parts=(
-            '<title>Change approve test model | Django site admin</title>',
             '<input type="submit" value="Save and Approve" name="_approve" class="extra_submit">',
             '<li>This field is required.</li>',
             'value="v3"',


### PR DESCRIPTION
These tests test that the `<title>` is laid out a certain way, but there is no guarantee by Django about that, and we see different strings in practice.
Simply remove them; these lines are not relevant to the functioning of the model.
