### PR TITLE
graphql_introspection: Add max_depth argument

### DIFF
--- a/bx_py_utils_tests/tests/graphql_introspection/shopify_product_only_depth2.snapshot.txt
+++ b/bx_py_utils_tests/tests/graphql_introspection/shopify_product_only_depth2.snapshot.txt
@@ -1,0 +1,129 @@
+{
+  availablePublicationCount 
+  collections {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  createdAt 
+  defaultCursor 
+  description 
+  descriptionHtml 
+  featuredImage {
+    altText 
+    height 
+    id 
+    metafield # More details hidden by max_depth
+    metafields # More details hidden by max_depth
+    originalSrc 
+    privateMetafield # More details hidden by max_depth
+    privateMetafields # More details hidden by max_depth
+    transformedSrc 
+    width 
+  }
+  featuredMedia # Skipping interface
+  feedback {
+    details # More details hidden by max_depth
+    summary 
+  }
+  giftCardTemplateSuffix 
+  handle 
+  hasOnlyDefaultVariant 
+  hasOutOfStockVariants 
+  id 
+  images {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  inCollection 
+  isGiftCard 
+  legacyResourceId 
+  media {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  mediaCount 
+  metafield {
+    createdAt 
+    description 
+    id 
+    key 
+    legacyResourceId 
+    namespace 
+    ownerType # Skipping enum
+    updatedAt 
+    value 
+    valueType # Skipping enum
+  }
+  metafields {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  onlineStorePreviewUrl 
+  onlineStoreUrl 
+  options {
+    id 
+    name 
+    position 
+    translations # More details hidden by max_depth
+    values 
+  }
+  priceRangeV2 {
+    maxVariantPrice # More details hidden by max_depth
+    minVariantPrice # More details hidden by max_depth
+  }
+  privateMetafield {
+    createdAt 
+    id 
+    key 
+    namespace 
+    updatedAt 
+    value 
+    valueType # Skipping enum
+  }
+  privateMetafields {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  productType 
+  publicationCount 
+  publishedAt 
+  publishedOnCurrentPublication 
+  publishedOnPublication 
+  requiresSellingPlan 
+  resourcePublications {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  resourcePublicationsV2 {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  sellingPlanGroupCount 
+  seo {
+    description 
+    title 
+  }
+  status # Skipping enum
+  storefrontId 
+  tags 
+  templateSuffix 
+  title 
+  totalInventory 
+  totalVariants 
+  tracksInventory 
+  translations {
+    key 
+    locale 
+    value 
+  }
+  unpublishedPublications {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  updatedAt 
+  variants {
+    edges # More details hidden by max_depth
+    pageInfo # More details hidden by max_depth
+  }
+  vendor 
+}

--- a/bx_py_utils_tests/tests/test_graphql_introspection.py
+++ b/bx_py_utils_tests/tests/test_graphql_introspection.py
@@ -36,3 +36,6 @@ class GraphQLIntrospectionTest(TestCase):
 
         got = complete_query(introspection_doc, 'Product')
         assert_text_snapshot(TEST_DIR, 'shopify_product_only', got)
+
+        depth2 = complete_query(introspection_doc, 'Product', max_depth=2)
+        assert_text_snapshot(TEST_DIR, 'shopify_product_only_depth2', depth2)


### PR DESCRIPTION
When evaluating a query, it can be very helpful to see only a given depth (like 2 or 3) to get a good overview of the available fields, but not recurse any deeper. Add that as an option.
