### PR TITLE
assert_text_snapshot: Allow specifying the extension

### DIFF
--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -9,11 +9,13 @@ def _write_json(obj, snapshot_file):
         json.dump(obj, snapshot_handle, ensure_ascii=False, indent=4, sort_keys=True)
 
 
-def assert_text_snapshot(root_dir: Union[pathlib.Path, str], snapshot_name: str, got: str):
+def assert_text_snapshot(root_dir: Union[pathlib.Path, str], snapshot_name: str, got: str,
+                         extension: str = '.txt'):
     assert re.match(r'^[-_.a-zA-Z0-9]+$', snapshot_name), f'Invalid snapshot name {snapshot_name}'
+    assert re.match(r'^[-_.a-zA-Z0-9]*$', extension), f'Invalid extension {extension!r}'
     assert isinstance(got, str)
 
-    snapshot_file = pathlib.Path(root_dir) / f'{snapshot_name}.snapshot.txt'
+    snapshot_file = pathlib.Path(root_dir) / f'{snapshot_name}.snapshot{extension}'
     try:
         expected = snapshot_file.read_text()
     except (FileNotFoundError, IOError, OSError):

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -36,3 +36,8 @@ def test_assert_text_snapshot():
         assert written_text == 'changed'
 
         assert_text_snapshot(tmp_dir, 'text', 'changed')
+
+        with pytest.raises(FileNotFoundError) as excinfo:
+            assert_text_snapshot(tmp_dir, 'text', TEXT, extension='.test2')
+        written_text = (pathlib.Path(tmp_dir) / 'text.snapshot.test2').read_text()
+        assert written_text == TEXT


### PR DESCRIPTION
Usually, snapshot files are created as `test_name.snapshot.txt`. For XML files it may be beneficial to name them `.xml`, so allow passing in an extension.
