### PR TITLE
Enhance snapshot test helper: Display ndiff error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Please take a look into the sources and tests for deeper informations.
 * `time.MockTimeMonotonicGenerator()` - Mock `time.monotonic()` with generic time stamps
 * `AssertQueries()` - Context manager with different checks of made database queries
 * `assert_json_requests_mock()` - Check the requests history of `requests_mock.mock()`
-* `assert_equal()` - Compare objects with a nice ndiff
-* `assert_snapshot` - Helper for quick snapshot test functionality (comparing value with one stored in a file)
+* `assert_equal()` - Compare objects with a nice ndiff using pformat
+* `assert_text_equal()` - Compare text strings with a nice ndiff
+* `assert_snapshot` - Helper for quick snapshot test functionality (comparing value with one stored in a file using json)
+* `assert_text_snapshot` - Same as `assert_snapshot` comparing text strings
 
 ### performance analysis
 

--- a/bx_py_utils/test_utils/assertion.py
+++ b/bx_py_utils/test_utils/assertion.py
@@ -3,6 +3,13 @@ import difflib
 from bx_py_utils.humanize.pformat import pformat
 
 
+def text_ndiff(txt1, txt2):
+    """
+    Generate a ndiff between two text strings.
+    """
+    return '\n'.join(difflib.ndiff(txt1.splitlines(), txt2.splitlines()))
+
+
 def pformat_ndiff(obj1, obj2):
     """
     Generate a ndiff from two objects, using pformat()
@@ -23,3 +30,15 @@ def assert_equal(obj1, obj2, msg=None):
         if not msg:
             msg = 'Objects are not equal:'
         raise AssertionError(f'{msg}\n{pformat_ndiff(obj1,obj2)}')
+
+
+def assert_text_equal(txt1, txt2, msg=None):
+    """
+    Check if the two text strings are the same. Display a error message with a ndiff.
+    """
+    assert isinstance(txt1, str)
+    assert isinstance(txt2, str)
+    if txt1 != txt2:
+        if not msg:
+            msg = 'Text not equal:'
+        raise AssertionError(f'{msg}\n{text_ndiff(txt1, txt2)}')

--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -3,6 +3,8 @@ import pathlib
 import re
 from typing import Union
 
+from bx_py_utils.test_utils.assertion import assert_equal, assert_text_equal
+
 
 def _write_json(obj, snapshot_file):
     with snapshot_file.open('w') as snapshot_handle:
@@ -18,14 +20,14 @@ def assert_text_snapshot(root_dir: Union[pathlib.Path, str], snapshot_name: str,
     snapshot_file = pathlib.Path(root_dir) / f'{snapshot_name}.snapshot{extension}'
     try:
         expected = snapshot_file.read_text()
-    except (FileNotFoundError, IOError, OSError):
+    except (FileNotFoundError, OSError):
         snapshot_file.write_text(got)
         raise
 
     if got != expected:
         snapshot_file.write_text(got)
 
-        assert got == expected
+        assert_text_equal(got, expected)  # display error message with ndiff
 
 
 def assert_snapshot(root_dir: Union[pathlib.Path, str], snapshot_name: str, got: Union[dict, list]):
@@ -36,11 +38,11 @@ def assert_snapshot(root_dir: Union[pathlib.Path, str], snapshot_name: str, got:
     try:
         with snapshot_file.open('r') as snapshot_handle:
             expected = json.load(snapshot_handle)
-    except (ValueError, IOError, FileNotFoundError, OSError):
+    except (ValueError, OSError, FileNotFoundError):
         _write_json(got, snapshot_file)
         raise
 
     if got != expected:
         _write_json(got, snapshot_file)
 
-        assert got == expected
+        assert_equal(got, expected)  # display error message with ndiff using pformat

--- a/bx_py_utils_tests/tests/test_assertion.py
+++ b/bx_py_utils_tests/tests/test_assertion.py
@@ -1,6 +1,8 @@
+import inspect
+
 from django.test import SimpleTestCase
 
-from bx_py_utils.test_utils.assertion import assert_equal
+from bx_py_utils.test_utils.assertion import assert_equal, assert_text_equal
 
 
 class AssertionTestCase(SimpleTestCase):
@@ -32,4 +34,31 @@ class AssertionTestCase(SimpleTestCase):
             assert_equal(
                 [{1: {2: 'two'}}],
                 [{1: {2: 'XXX'}}]
+            )
+
+    def test_assert_text_equal(self):
+        assert_text_equal(txt1='foo', txt2='foo')
+
+        with self.assertRaisesMessage(AssertionError, 'Text not equal:\n- 1\n+ 2'):
+            assert_text_equal('1', '2')
+
+        msg = (
+            'Text not equal:\n'
+            '  one\n'
+            '- tWo\n'
+            '+ two\n'
+            '  three'
+        )
+        with self.assertRaisesMessage(AssertionError, msg):
+            assert_text_equal(
+                inspect.cleandoc('''
+                    one
+                    tWo
+                    three
+                '''),
+                inspect.cleandoc('''
+                    one
+                    two
+                    three
+                '''),
             )

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -16,28 +16,48 @@ def test_assert_snapshot():
 
         assert_snapshot(tmp_dir, 'snap', [{'foo': 42, 'bär': 5}])
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError) as exc_info:
             assert_snapshot(tmp_dir, 'snap', [{'foo': 42, 'bär': 23}])
+        assert exc_info.value.args[0] == (
+            'Objects are not equal:\n'
+            '  [\n'
+            '      {\n'
+            '-         "bär": 23,\n'
+            '?                ^^\n'
+            '\n'
+            '+         "bär": 5,\n'
+            '?                ^\n'
+            '\n'
+            '          "foo": 42\n'
+            '      }\n'
+            '  ]'
+        )
 
 
 def test_assert_text_snapshot():
     with tempfile.TemporaryDirectory() as tmp_dir:
         TEXT = 'this is\nmultiline "text"'
-        with pytest.raises(FileNotFoundError) as excinfo:
+        with pytest.raises(FileNotFoundError):
             assert_text_snapshot(tmp_dir, 'text', TEXT)
         written_text = (pathlib.Path(tmp_dir) / 'text.snapshot.txt').read_text()
         assert written_text == TEXT
 
         assert_text_snapshot(tmp_dir, 'text', TEXT)
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError) as exc_info:
             assert_text_snapshot(tmp_dir, 'text', 'changed')
         written_text = (pathlib.Path(tmp_dir) / 'text.snapshot.txt').read_text()
         assert written_text == 'changed'
+        assert exc_info.value.args[0] == (
+            'Text not equal:\n'
+            '- changed\n'
+            '+ this is\n'
+            '+ multiline "text"'
+        )
 
         assert_text_snapshot(tmp_dir, 'text', 'changed')
 
-        with pytest.raises(FileNotFoundError) as excinfo:
+        with pytest.raises(FileNotFoundError):
             assert_text_snapshot(tmp_dir, 'text', TEXT, extension='.test2')
         written_text = (pathlib.Path(tmp_dir) / 'text.snapshot.test2').read_text()
         assert written_text == TEXT


### PR DESCRIPTION
* Add `assert_text_equal` and use it for `assert_text_snapshot`
* Use existing `assert_equal` for `assert_snapshot`

So the snapshot tests will raise a error with a ndiff. This may be helpful in CI pipelines.