### PR TITLE
Add assert_py_snapshot() that use PrettyPrinter() to support more Python objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Please take a look into the sources and tests for deeper informations.
 * `assert_text_equal()` - Compare text strings with a nice diff
 * `assert_snapshot` - Helper for quick snapshot test functionality (comparing value with one stored in a file using json)
 * `assert_text_snapshot` - Same as `assert_snapshot` comparing text strings
+* `assert_py_snapshot` - Snapshot test using `PrettyPrinter()`
 
 ### performance analysis
 


### PR DESCRIPTION
The current snapshot tests used JSON and JSON can't serialize all types of Python objects. e.g.:
UUID, datetime, Decimal etc. It's possible to expand the JSONEncoder to serialize them. But then a
compare beween a UUID instance or a string that looks like a UUID is not possible ;)