### PR TITLE
Remove obsolete "python-stdnum"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ readme='README.md'
 
 [tool.poetry.dependencies]
 python = '>=3.6,<4.0.0'
-python-stdnum = "*"  # https://arthurdejong.org/python-stdnum/
 
 [tool.poetry.dev-dependencies]
 boto3 = "*"  # needed for e.g.: bx_py_utils/aws/ stuff!


### PR DESCRIPTION
This one was overlooked: It's only needed in
https://github.com/boxine/bx_django_utils/tree/master/bx_django_utils/data_types/gtin