### PR TITLE
Add optional "self file path" to all snapshot functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Please take a look into the sources and tests for deeper informations.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L160) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L127) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L95) - Assert "text" string via snapshot file
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L166) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L132) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L99) - Assert "text" string via snapshot file
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import pytest
 
 import bx_py_utils
+from bx_py_utils.test_utils import snapshot
 from bx_py_utils.test_utils.assertion import pformat_ndiff, text_ndiff
 from bx_py_utils.test_utils.datetime import parse_dt
 from bx_py_utils.test_utils.filesystem_utils import FileWatcher
@@ -272,3 +273,12 @@ def test_assert_text_snapshot_auto_names():
         _AUTO_SNAPSHOT_NAME_COUNTER.clear()
 
         assert_text_snapshot(got=example)
+
+        # We would like to check the same file ;)
+        _AUTO_SNAPSHOT_NAME_COUNTER.clear()
+
+        # We can specify the path used to get the caller stack frame:
+        assert_text_snapshot(
+            got=example,
+            self_file_path=pathlib.Path(snapshot.__file__)
+        )


### PR DESCRIPTION
If a snapshot function will be used indirect by a helper in a other project file, then we have to
pass the correct file path to get the correct caller stack frame.