### PR TITLE
Add start+end line number to auto doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,114 +20,115 @@ Please take a look into the sources and tests for deeper informations.
 
 ### bx_py_utils.anonymize
 
-* [`anonymize()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/anonymize.py#L15) - Anonymize the given string with special handling for eMail addresses.
+* [`anonymize()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/anonymize.py#L15-L41) - Anonymize the given string with special handling for eMail addresses.
 
 ### bx_py_utils.auto_doc
 
-* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L104) - Check and update README file with generate_modules_doc()
-* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L34) - Generate a list of function/class information via pdoc.
+* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L121-L163) - Check and update README file with generate_modules_doc()
+* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L43-L118) - Generate a list of function/class information via pdoc.
+* [`get_code_location()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L35-L40) - Return start and end line number for an object via inspect.
 
 #### bx_py_utils.aws.client_side_cert_manager
 
-* [`ClientSideCertManager()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/aws/client_side_cert_manager.py#L6) - Helper to manage client-side TLS certificate via AWS Secrets Manager by
+* [`ClientSideCertManager()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/aws/client_side_cert_manager.py#L6-L72) - Helper to manage client-side TLS certificate via AWS Secrets Manager by
 
 #### bx_py_utils.aws.secret_manager
 
-* [`SecretsManager()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/aws/secret_manager.py#L4) - Access AWS Secrets Manager values
+* [`SecretsManager()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/aws/secret_manager.py#L4-L34) - Access AWS Secrets Manager values
 
 ### bx_py_utils.compat
 
-* [`removeprefix()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/compat.py#L1) - Backport of `removeprefix` from PEP-616 (Python 3.9+)
-* [`removesuffix()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/compat.py#L10) - Backport of `removesuffix` from PEP-616 (Python 3.9+)
+* [`removeprefix()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/compat.py#L1-L7) - Backport of `removeprefix` from PEP-616 (Python 3.9+)
+* [`removesuffix()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/compat.py#L10-L16) - Backport of `removesuffix` from PEP-616 (Python 3.9+)
 
 ### bx_py_utils.dict_utils
 
-* [`dict_get()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L4) - nested dict `get()`
-* [`pluck()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L28) - Extract values from a dict, if they are present
+* [`dict_get()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L4-L25) - nested dict `get()`
+* [`pluck()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L28-L40) - Extract values from a dict, if they are present
 
 ### bx_py_utils.environ
 
-* [`cgroup_memory_usage()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/environ.py#L9) - Returns the memory usage of the cgroup the Python interpreter is running in.
+* [`cgroup_memory_usage()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/environ.py#L9-L25) - Returns the memory usage of the cgroup the Python interpreter is running in.
 
 ### bx_py_utils.error_handling
 
-* [`print_exc_plus()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/error_handling.py#L14) - Print traceback information with a listing of all the local variables in each frame.
+* [`print_exc_plus()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/error_handling.py#L14-L72) - Print traceback information with a listing of all the local variables in each frame.
 
 ### bx_py_utils.graphql_introspection
 
-* [`introspection_query()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/graphql_introspection.py#L5) - Generate GraphQL introspection query with variable nested depth.
+* [`introspection_query()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/graphql_introspection.py#L5-L25) - Generate GraphQL introspection query with variable nested depth.
 
 ### bx_py_utils.hash_utils
 
-* [`url_safe_encode()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/hash_utils.py#L13) - Encode bytes into a URL safe string.
-* [`url_safe_hash()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/hash_utils.py#L25) - Generate a URL safe hash with `max_size` from given string/bytes.
+* [`url_safe_encode()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/hash_utils.py#L13-L22) - Encode bytes into a URL safe string.
+* [`url_safe_hash()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/hash_utils.py#L25-L46) - Generate a URL safe hash with `max_size` from given string/bytes.
 
 #### bx_py_utils.humanize.pformat
 
-* [`pformat()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/humanize/pformat.py#L5) - Format given object: Try JSON fist and fallback to pformat()
+* [`pformat()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/humanize/pformat.py#L5-L16) - Format given object: Try JSON fist and fallback to pformat()
 
 #### bx_py_utils.humanize.time
 
-* [`human_timedelta()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/humanize/time.py#L14) - Converts a time duration into a friendly text representation.
+* [`human_timedelta()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/humanize/time.py#L14-L52) - Converts a time duration into a friendly text representation.
 
 ### bx_py_utils.iteration
 
-* [`chunk_iterable()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/iteration.py#L4) - Returns a generator that yields slices of iterable of the given `chunk_size`.
+* [`chunk_iterable()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/iteration.py#L4-L21) - Returns a generator that yields slices of iterable of the given `chunk_size`.
 
 ### bx_py_utils.path
 
-* [`assert_is_dir()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/path.py#L4) - Check if given path is a directory
-* [`assert_is_file()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/path.py#L15) - Check if given path is a file
+* [`assert_is_dir()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/path.py#L4-L12) - Check if given path is a directory
+* [`assert_is_file()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/path.py#L15-L25) - Check if given path is a file
 
 ### bx_py_utils.processify
 
-* [`processify()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/processify.py#L12) - Decorator to run a function as a process.
+* [`processify()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/processify.py#L12-L53) - Decorator to run a function as a process.
 
 ### bx_py_utils.stack_info
 
-* [`FrameNotFound()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L8) - Base class for lookup errors.
-* [`last_frame_outside_path()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L16) - Returns the stack frame that is the direct successor of given "file_path".
+* [`FrameNotFound()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L8-L13) - Base class for lookup errors.
+* [`last_frame_outside_path()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L16-L44) - Returns the stack frame that is the direct successor of given "file_path".
 
 #### bx_py_utils.test_utils.assertion
 
-* [`assert_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L52) - Check if the two objects are the same. Display a nice diff, using `pformat()`
-* [`assert_text_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L68) - Check if the two text strings are the same. Display a error message with a diff.
-* [`pformat_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L14) - Generate a `ndiff` from two objects, using `pformat()`
-* [`pformat_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L45) - Generate a unified diff from two objects, using `pformat()`
-* [`text_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L6) - Generate a `ndiff` between two text strings.
-* [`text_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L38) - Generate a unified diff between two text strings.
+* [`assert_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L52-L65) - Check if the two objects are the same. Display a nice diff, using `pformat()`
+* [`assert_text_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L68-L83) - Check if the two text strings are the same. Display a error message with a diff.
+* [`pformat_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L14-L24) - Generate a `ndiff` from two objects, using `pformat()`
+* [`pformat_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L45-L49) - Generate a unified diff from two objects, using `pformat()`
+* [`text_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L6-L11) - Generate a `ndiff` between two text strings.
+* [`text_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L38-L42) - Generate a unified diff between two text strings.
 
 #### bx_py_utils.test_utils.datetime
 
-* [`parse_dt()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/datetime.py#L4) - Helper for easy generate a `datetime` instance via string.
+* [`parse_dt()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/datetime.py#L4-L15) - Helper for easy generate a `datetime` instance via string.
 
 #### bx_py_utils.test_utils.filesystem_utils
 
-* [`FileWatcher()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/filesystem_utils.py#L6) - Helper to record which new files have been created.
+* [`FileWatcher()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/filesystem_utils.py#L6-L49) - Helper to record which new files have been created.
 
 #### bx_py_utils.test_utils.mock_aws_secret_manager
 
-* [`SecretsManagerMock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mock_aws_secret_manager.py#L1) - Mock for `bx_py_utils.aws.secret_manager.SecretsManager()`
+* [`SecretsManagerMock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mock_aws_secret_manager.py#L1-L16) - Mock for `bx_py_utils.aws.secret_manager.SecretsManager()`
 
 #### bx_py_utils.test_utils.mock_boto3session
 
-* [`MockedBoto3Session()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mock_boto3session.py#L4) - Mock for `boto3.session.Session()`
+* [`MockedBoto3Session()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mock_boto3session.py#L4-L46) - Mock for `boto3.session.Session()`
 
 #### bx_py_utils.test_utils.requests_mock_assertion
 
-* [`assert_json_requests_mock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L6) - Check the requests history.
+* [`assert_json_requests_mock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L6-L33) - Check the requests history.
 
 #### bx_py_utils.test_utils.snapshot
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L166) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L132) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L99) - Assert "text" string via snapshot file
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L166-L200) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L132-L163) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L99-L129) - Assert "text" string via snapshot file
 
 #### bx_py_utils.test_utils.time
 
-* [`MockTimeMonotonicGenerator()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/time.py#L1) - Helper to mock `time.monotonic()` in tests.
+* [`MockTimeMonotonicGenerator()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/time.py#L1-L19) - Helper to mock `time.monotonic()` in tests.
 
 [comment]: <> (✂✂✂ auto generated end ✂✂✂)
 

--- a/bx_py_utils_tests/tests/test_readme.py
+++ b/bx_py_utils_tests/tests/test_readme.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 import bx_py_utils
 from bx_py_utils.auto_doc import ModulePath, assert_readme, generate_modules_doc
 
@@ -34,10 +36,11 @@ def test_generate_modules_doc_with_links():
     doc_block = generate_modules_doc(
         modules=['bx_py_utils.auto_doc'],
         start_level=0,
-        link_template='https://test.tld/blob/master/{path}#L{lnum}',
+        link_template='https://test.tld/blob/master/{path}#L{start}-L{end}',
     )
     assert (
-        '* [`assert_readme()`](https://test.tld/blob/master/bx_py_utils/auto_doc.py#L104) - Check'
+        '* [`assert_readme()`](https://test.tld/blob/master/bx_py_utils/auto_doc.py#L121-L163)'
+        ' - Check'
     ) in doc_block
 
 
@@ -54,5 +57,24 @@ def test_auto_doc_in_readme():
         start_marker_line='[comment]: <> (✂✂✂ auto generated start ✂✂✂)',
         end_marker_line='[comment]: <> (✂✂✂ auto generated end ✂✂✂)',
         start_level=2,
-        link_template='https://github.com/boxine/bx_py_utils/blob/master/{path}#L{lnum}'
+        link_template='https://github.com/boxine/bx_py_utils/blob/master/{path}#L{start}-L{end}'
     )
+
+
+def test_old_link_template_pattern():
+    if sys.version_info < (3, 7):
+        # pdoc is not compatible with Python 3.6
+        return
+
+    with pytest.deprecated_call(match=(
+        '"lnum" in "link_template" will be removed in the future. Change it to "start"'
+    )):
+        doc_block = generate_modules_doc(
+            modules=['bx_py_utils.auto_doc'],
+            start_level=0,
+            link_template='https://test.tld/blob/master/{path}#L{lnum}',
+        )
+        assert doc_block
+    assert (
+        '* [`assert_readme()`](https://test.tld/blob/master/bx_py_utils/auto_doc.py#L121) - Check'
+    ) in doc_block


### PR DESCRIPTION
Use `inspect.getsourcelines()` instead of undocumented `inspect.findsource()`:

https://docs.python.org/3/library/inspect.html#inspect.getsourcelines

Change the pattern with `start` + `end` and deprecated the old `lnum`