### PR TITLE
assert_text_snapshot: Make sure it fails if newlines change

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ Please take a look into the sources and tests for deeper informations.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L167-L201) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L132-L164) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L99-L129) - Assert "text" string via snapshot file
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L171-L205) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L136-L168) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L100-L133) - Assert "text" string via snapshot file
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -158,6 +158,21 @@ def test_assert_text_snapshot():
         written_text = (pathlib.Path(tmp_dir) / 'text.snapshot.test2').read_text()
         assert written_text == TEXT
 
+        # Newlines
+        UNIX_TEXT = 'a\nnewline'
+        WINDOWS_TEXT = 'a\r\nnewline'
+        with pytest.raises(FileNotFoundError):
+            assert_text_snapshot(tmp_dir, 'newlines', UNIX_TEXT)
+        written_bytes = (pathlib.Path(tmp_dir) / 'newlines.snapshot.txt').read_bytes()
+        assert written_bytes == UNIX_TEXT.encode('utf-8')
+
+        with pytest.raises(AssertionError) as exc_info:
+            assert_text_snapshot(tmp_dir, 'newlines', WINDOWS_TEXT)
+        written_bytes = (pathlib.Path(tmp_dir) / 'newlines.snapshot.txt').read_bytes()
+        assert written_bytes == WINDOWS_TEXT.encode('utf-8')
+        assert exc_info.value.args[0] == (
+            '''Differing newlines: Expected 'a\\nnewline', got 'a\\r\\nnewline\''''
+        )
 
 def test_assert_py_snapshot():
     example = {


### PR DESCRIPTION
Explicitly and manually convert text.
