### PR TITLE
Add assert_html_snapshot() with pretty format via lxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ Please take a look into the sources and tests for deeper informations.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L171-L205) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L136-L168) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L100-L133) - Assert "text" string via snapshot file
+* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L215-L252) - Assert "html" string via snapshot file with pretty format via lxml
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L178-L212) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L143-L175) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L107-L140) - Assert "text" string via snapshot file
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -8,6 +8,13 @@ import re
 from collections import Counter
 from typing import Any, Callable, Optional, Union
 
+
+try:
+    from lxml import etree, html
+except ModuleNotFoundError:
+    etree = None
+
+
 from bx_py_utils.compat import removeprefix
 from bx_py_utils.path import assert_is_dir
 from bx_py_utils.stack_info import last_frame_outside_path
@@ -203,3 +210,44 @@ def assert_py_snapshot(
             fromfile=fromfile, tofile=tofile,
             diff_func=diff_func
         )
+
+
+def assert_html_snapshot(
+    root_dir: Union[pathlib.Path, str] = None,
+    snapshot_name: str = None,
+    got: str = None,
+    extension: str = '.html',
+    fromfile: str = 'got',
+    tofile: str = 'expected',
+    diff_func: Callable = text_unified_diff,
+    self_file_path: Union[pathlib.Path, str] = None,
+    method="xml",  # etree.tostring output: 'xml', 'html' etc.
+):
+    """
+    Assert "html" string via snapshot file with pretty format via lxml
+    """
+    if etree is None:
+        raise ModuleNotFoundError(
+            'The "lxml" package is needed for this function'
+            ' (Hint: assert_text_snapshot() as fallback)!'
+        )
+
+    assert isinstance(got, str)
+
+    got = etree.tostring(
+        html.fromstring(got),
+        encoding='unicode',
+        method=method,
+        pretty_print=True
+    )
+
+    assert_text_snapshot(
+        root_dir=root_dir,
+        snapshot_name=snapshot_name,
+        got=got,
+        extension=extension,
+        fromfile=fromfile,
+        tofile=tofile,
+        diff_func=diff_func,
+        self_file_path=self_file_path,
+    )

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot_assert_html_snapshot_1.snapshot.html
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot_assert_html_snapshot_1.snapshot.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <h1>This is a Heading</h1>
+    <p>This is a paragraph.</p>
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ flynt = '*'
 autopep8 = '*'
 isort = '*'
 poetry-publish = "*"  # https://github.com/jedie/poetry-publish
+lxml = "*"
 
 # pdoc > 0.4.1 needs Python 3.7, but we still support 3.6,
 # so we must install pdoc only with 3.7 or newer, to get a up-to-date version.


### PR DESCRIPTION
Add `lxml` only as "dev dependencies" to avoid install it in projects that didn't need it and didn't
use this new `assert_html_snapshot()`.

Raise a helpful error message if it's not installed.