### PR TITLE
Refactor assert_html_snapshot() and use BeautifulSoup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Please take a look into the sources and tests for deeper informations.
 * [`url_safe_encode()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/hash_utils.py#L13-L22) - Encode bytes into a URL safe string.
 * [`url_safe_hash()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/hash_utils.py#L25-L46) - Generate a URL safe hash with `max_size` from given string/bytes.
 
+### bx_py_utils.html_utils
+
+* [`InvalidHtml()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L15-L19) - Exception class used in validate_html() on HTML parse/validate error.
+* [`pretty_format_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L47-L61) - Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
+* [`validate_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L22-L44) - Validate a HTML document (Needs 'lxml' package)
+
 #### bx_py_utils.humanize.pformat
 
 * [`pformat()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/humanize/pformat.py#L5-L16) - Format given object: Try JSON fist and fallback to pformat()
@@ -129,10 +135,10 @@ Please take a look into the sources and tests for deeper informations.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L215-L253) - Assert "html" string via snapshot file with pretty format via lxml
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L178-L212) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L143-L175) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L107-L140) - Assert "text" string via snapshot file
+* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L223-L255) - Assert "html" string via snapshot file with validate and pretty format
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L186-L220) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L151-L183) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L115-L148) - Assert "text" string via snapshot file
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils/html_utils.py
+++ b/bx_py_utils/html_utils.py
@@ -1,0 +1,61 @@
+try:
+    from lxml import html  # lxml is optional requirement
+except ModuleNotFoundError:
+    html = None
+else:
+    from lxml.etree import XMLSyntaxError
+
+
+try:
+    from bs4 import BeautifulSoup  # BeautifulSoup4 is optional requirement
+except ModuleNotFoundError:
+    BeautifulSoup = None
+
+
+class InvalidHtml(AssertionError):
+    """
+    Exception class used in validate_html() on HTML parse/validate error.
+    """
+    pass
+
+
+def validate_html(data):
+    """
+    Validate a HTML document (Needs 'lxml' package)
+
+    There are a few more ways to validate HTML documents,
+    but the intention here is just to raise an error on
+    really broken documents.
+    """
+    assert isinstance(data, str)
+
+    if html is None:
+        raise ModuleNotFoundError(
+            'This feature needs "lxml", please add it to you requirements'
+        )
+
+    parser = html.HTMLParser(
+        recover=False,  # Crash faster on broken HTML
+    )
+    try:
+        parser.feed(data)
+        parser.close()
+    except XMLSyntaxError as err:
+        raise InvalidHtml(err)
+
+
+def pretty_format_html(data):
+    """
+    Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
+    """
+    assert isinstance(data, str)
+
+    if BeautifulSoup is None:
+        raise ModuleNotFoundError(
+            'This feature needs "beautifulsoup4", please add it to you requirements'
+        )
+
+    soup = BeautifulSoup(data, 'html.parser')
+    return soup.prettify(
+        formatter=None  # Do not perform any substitution
+    )

--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -8,11 +8,19 @@ import re
 from collections import Counter
 from typing import Any, Callable, Optional, Union
 
+from bx_py_utils.html_utils import pretty_format_html, validate_html
+
 
 try:
-    from lxml import etree, html
+    from lxml import html  # lxml is optional requirement
 except ModuleNotFoundError:
-    etree = None
+    html = None
+
+
+try:
+    from bs4 import BeautifulSoup  # BeautifulSoup4 is optional requirement
+except ModuleNotFoundError:
+    BeautifulSoup = None
 
 
 from bx_py_utils.compat import removeprefix
@@ -221,25 +229,19 @@ def assert_html_snapshot(
     tofile: str = 'expected',
     diff_func: Callable = text_unified_diff,
     self_file_path: Union[pathlib.Path, str] = None,
-    method="xml",  # etree.tostring output: 'xml', 'html' etc.
+    validate: bool = True,
+    pretty_format: bool = True,
 ):
     """
-    Assert "html" string via snapshot file with pretty format via lxml
+    Assert "html" string via snapshot file with validate and pretty format
     """
-    if etree is None:
-        raise ModuleNotFoundError(
-            'The "lxml" package is needed for this function'
-            ' (Hint: assert_text_snapshot() as fallback)!'
-        )
-
     assert isinstance(got, str)
 
-    got = etree.tostring(
-        html.fromstring(got),
-        encoding='unicode',
-        method=method,
-        pretty_print=True
-    )
+    if validate:
+        validate_html(got)
+
+    if pretty_format:
+        got = pretty_format_html(got)
 
     assert_text_snapshot(
         root_dir=root_dir,

--- a/bx_py_utils_tests/tests/test_html_utils.py
+++ b/bx_py_utils_tests/tests/test_html_utils.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+import pytest
+
+from bx_py_utils import html_utils
+from bx_py_utils.html_utils import InvalidHtml, pretty_format_html, validate_html
+
+
+def test_validate_html():
+    validate_html('<p>Test</p>')
+    validate_html('<a><b/></a>')
+
+    with pytest.raises(InvalidHtml) as exc_info:
+        validate_html('<foo></bar>')
+    assert str(exc_info.value.args[0]) == (
+        'Tag foo invalid, line 1, column 5 (<string>, line 1)'
+    )
+
+    with pytest.raises(InvalidHtml) as exc_info:
+        validate_html('<p> >broken< </p>')
+    assert str(exc_info.value.args[0]) == (
+        'htmlParseStartTag: invalid element name, line 1, column 13 (<string>, line 1)'
+    )
+
+    # Our helpful error message if requirements missing?
+
+    with patch.object(html_utils, 'html', None), \
+            pytest.raises(ModuleNotFoundError) as cm:
+        validate_html('')
+
+    assert str(cm.value) == (
+        'This feature needs "lxml", please add it to you requirements'
+    )
+
+
+def test_pretty_format_html():
+    assert pretty_format_html('<p>Test</p>') == '<p>\n Test\n</p>'
+
+    html = pretty_format_html('''
+         \r\n <h1>X</h1> \r\n \r\n
+        <p><strong>Test</strong></p> \r\n \r\n
+    ''')
+    assert html == '<h1>\n X\n</h1>\n<p>\n <strong>\n  Test\n </strong>\n</p>\n'
+
+    # Our helpful error message if requirements missing?
+
+    with patch.object(html_utils, 'BeautifulSoup', None), \
+            pytest.raises(ModuleNotFoundError) as cm:
+        pretty_format_html('')
+
+    assert str(cm.value) == (
+        'This feature needs "beautifulsoup4", please add it to you requirements'
+    )

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -9,6 +9,7 @@ from uuid import UUID
 import pytest
 
 import bx_py_utils
+from bx_py_utils import html_utils
 from bx_py_utils.path import assert_is_file
 from bx_py_utils.test_utils import snapshot
 from bx_py_utils.test_utils.assertion import pformat_ndiff, text_ndiff
@@ -312,42 +313,21 @@ def test_assert_text_snapshot_auto_names():
 
 
 def test_assert_html_snapshot():
-    html = (
-        '<!DOCTYPE html><html><head><title>Page Title</title></head><body>'
-        '<h1>This is a Heading</h1><p>This is a paragraph.</p></body></html>'
-    )
-
-    snapshot_path = SELF_PATH / (
-        'test_test_utils_snapshot_assert_html_snapshot_1.snapshot.html'
-    )
-    assert_is_file(snapshot_path)
-
+    html = '''
+        <!DOCTYPE html> \r\n <html> \r\n  \r\n <head>
+         \r\n  \r\n <title \r\n >Page Title</title></head> \r\n  \r\n <body>
+        <h1>This is a Heading</ \r\n h1> \r\n  \r\n
+        <p \r\n >This is a paragraph.</p> \r\n  \r\n
+        </body> \r\n  \r\n </ \r\n html>
+    '''
     assert_html_snapshot(got=html)
-
-    formated_html = snapshot_path.read_text()
-
-    # etree pretty print adds a leading new line, but cleandoc not ;)
-    formated_html = formated_html.rstrip('\n')
-
-    assert formated_html == inspect.cleandoc('''
-        <html>
-          <head>
-            <title>Page Title</title>
-          </head>
-          <body>
-            <h1>This is a Heading</h1>
-            <p>This is a paragraph.</p>
-          </body>
-        </html>
-    ''')
 
 
 def test_assert_html_snapshot_without_lxml():
-    with patch.object(snapshot, 'etree', None), \
+    with patch.object(html_utils, 'html', None), \
             pytest.raises(ModuleNotFoundError) as cm:
-        assert_html_snapshot()
+        assert_html_snapshot(got='')
 
     assert str(cm.value) == (
-        'The "lxml" package is needed for this function'
-        ' (Hint: assert_text_snapshot() as fallback)!'
+        'This feature needs "lxml", please add it to you requirements'
     )

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot_assert_html_snapshot_1.snapshot.html
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot_assert_html_snapshot_1.snapshot.html
@@ -1,9 +1,16 @@
+<!DOCTYPE html>
 <html>
-  <head>
-    <title>Page Title</title>
-  </head>
-  <body>
-    <h1>This is a Heading</h1>
-    <p>This is a paragraph.</p>
-  </body>
+ <head>
+  <title>
+   Page Title
+  </title>
+ </head>
+ <body>
+  <h1>
+   This is a Heading
+  </h1>
+  <p>
+   This is a paragraph.
+  </p>
+ </body>
 </html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ flynt = '*'
 autopep8 = '*'
 isort = '*'
 poetry-publish = "*"  # https://github.com/jedie/poetry-publish
+beautifulsoup4 = "*"
 lxml = "*"
 
 # pdoc > 0.4.1 needs Python 3.7, but we still support 3.6,


### PR DESCRIPTION
Fix https://github.com/boxine/bx_py_utils/issues/94

`etree.tostring()` with `pretty_print` can't handle whitespaces very good. It also changes the HTML
document more than BeautifulSoup.

Split the code and create intepend useable functions:

* `validate_html()`
* `pretty_format_html()`

`assert_html_snapshot()` will use both as default.

`validate_html()` may be enhanced. There are a few more ways to validate HTML documents, but the
intention here is just to raise an error on really broken documents. Because `BeautifulSoup` will
consume broken documents: Validate them before pretty format.