### PR TITLE
mocks3: Add debug output helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Please take a look into the sources and tests for deeper informations.
 
 A simple mock for Boto3's S3 modules.
 
-* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L39-L113) - Simulates a boto3 S3 client object in tests
+* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L39-L145) - Simulates a boto3 S3 client object in tests
 
 #### bx_py_utils.test_utils.requests_mock_assertion
 

--- a/bx_py_utils_tests/tests/test_test_utils_mocks3.py
+++ b/bx_py_utils_tests/tests/test_test_utils_mocks3.py
@@ -1,0 +1,19 @@
+import time
+from unittest import mock
+
+from bx_py_utils.test_utils.mocks3 import PseudoS3Client
+from bx_py_utils.test_utils.snapshot import assert_text_snapshot
+
+
+def test_debug_long_repr():
+    s3 = PseudoS3Client(init_buckets=('b-bucket', 'a-bucket'))
+    s3.mock_set_content('a-bucket', 'a-key', b'<?xml?><a complicated="document">')
+    s3.mock_set_content('a-bucket', 'empty', b'')
+    s3.mock_set_content('a-bucket', 'binary', b'\xf0\x00' * 42)
+    s3.mock_set_content('a-bucket', 'png', b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x04\xb0')
+    s3.mock_set_content('a-bucket', 'short', b'short')
+    s3.mock_set_content('a-bucket', 'short-binary', b's\x00\xf0hort')
+    s3.mock_set_content('b-bucket', 'very-long-key-that-is-way-too-long', b'but short content')
+
+    got = s3.debug_long_repr()
+    assert_text_snapshot(got=got)

--- a/bx_py_utils_tests/tests/test_test_utils_mocks3_debug_long_repr_1.snapshot.txt
+++ b/bx_py_utils_tests/tests/test_test_utils_mocks3_debug_long_repr_1.snapshot.txt
@@ -1,0 +1,11 @@
+<MockS3
+a-bucket
+  a-key                => [21 bytes] '<?xml?><a complic...
+  binary               => [19 bytes] b'\xf0\x00\xf0\x...
+  empty                => [0 bytes] 
+  png                  => [19 bytes] b'\x89PNG\r\n\x1...
+  short                => [7 bytes] 'short'
+  short-binary         => [16 bytes] b's\x00\xf0hort'
+b-bucket
+  very-long-key-that-is-way-too-long => [19 bytes] 'but short content'
+>


### PR DESCRIPTION
Add helper functions to quickly print the contents of test buckets.
