### PR TITLE
mocks3: More realistic download options

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Please take a look into the sources and tests for deeper informations.
 
 A simple mock for Boto3's S3 modules.
 
-* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L39-L145) - Simulates a boto3 S3 client object in tests
+* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L39-L152) - Simulates a boto3 S3 client object in tests
 
 #### bx_py_utils.test_utils.requests_mock_assertion
 

--- a/bx_py_utils/test_utils/mocks3.py
+++ b/bx_py_utils/test_utils/mocks3.py
@@ -48,21 +48,28 @@ class PseudoS3Client:
         for bucket_name in init_buckets:
             self.buckets[bucket_name] = {}
 
-    def download_file(self, bucket, s3_key, local_file):
-        bucket = self.buckets[bucket]
-        storage = getattr(bucket, 'bucket_storage', bucket)
-        if s3_key not in storage:
-            raise self.exceptions.NoSuchKey(s3_key)
-        with open(local_file, 'wb') as f:
-            f.write(storage[s3_key])
+    # non-standard variable names for Boto3 compatibility
+    def download_file(self, Bucket, Key, Filename):
+        bucket = self.buckets[Bucket]
+        if Key not in bucket:
+            raise self.exceptions.NoSuchKey(Key)
+        with open(Filename, 'wb') as f:
+            f.write(bucket[Key])
+
+    # non-standard variable names for Boto3 compatibility
+    def download_fileobj(self, Bucket, Key, Fileobj):
+        bucket = self.buckets[Bucket]
+        if Key not in bucket:
+            raise self.exceptions.NoSuchKey(Key)
+        Fileobj.write(bucket[Key])
 
     # non-standard variable names for Boto3 compatibility
     def get_object(self, *, Bucket, Key):
-        storage = self.buckets[Bucket]
-        if Key not in storage:
+        bucket = self.buckets[Bucket]
+        if Key not in bucket:
             raise self.exceptions.NoSuchKey(Key)
 
-        content = storage[Key]
+        content = bucket[Key]
         return {
             'Body': PseudoBotoIO(content),
             'ContentLength': len(content),

--- a/bx_py_utils_tests/tests/test_test_utils_mocks3.py
+++ b/bx_py_utils_tests/tests/test_test_utils_mocks3.py
@@ -1,19 +1,59 @@
-import time
-from unittest import mock
+import io
+import pathlib
+import tempfile
+from unittest import TestCase
 
 from bx_py_utils.test_utils.mocks3 import PseudoS3Client
 from bx_py_utils.test_utils.snapshot import assert_text_snapshot
 
 
-def test_debug_long_repr():
-    s3 = PseudoS3Client(init_buckets=('b-bucket', 'a-bucket'))
-    s3.mock_set_content('a-bucket', 'a-key', b'<?xml?><a complicated="document">')
-    s3.mock_set_content('a-bucket', 'empty', b'')
-    s3.mock_set_content('a-bucket', 'binary', b'\xf0\x00' * 42)
-    s3.mock_set_content('a-bucket', 'png', b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x04\xb0')
-    s3.mock_set_content('a-bucket', 'short', b'short')
-    s3.mock_set_content('a-bucket', 'short-binary', b's\x00\xf0hort')
-    s3.mock_set_content('b-bucket', 'very-long-key-that-is-way-too-long', b'but short content')
+class S3MockTest(TestCase):
+    def test_debug_long_repr(self):
+        s3 = PseudoS3Client(init_buckets=('b-bucket', 'a-bucket'))
+        s3.mock_set_content('a-bucket', 'a-key', b'<?xml?><a complicated="document">')
+        s3.mock_set_content('a-bucket', 'empty', b'')
+        s3.mock_set_content('a-bucket', 'binary', b'\xf0\x00' * 42)
+        s3.mock_set_content('a-bucket', 'png', b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x04\xb0')
+        s3.mock_set_content('a-bucket', 'short', b'short')
+        s3.mock_set_content('a-bucket', 'short-binary', b's\x00\xf0hort')
+        s3.mock_set_content('b-bucket', 'very-long-key-that-is-way-too-long', b'but short content')
 
-    got = s3.debug_long_repr()
-    assert_text_snapshot(got=got)
+        got = s3.debug_long_repr()
+        assert_text_snapshot(got=got)
+
+    def test_various_get_file(self):
+        s3 = PseudoS3Client(init_buckets=('buck',))
+        content = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x04\xb0'
+        s3.mock_set_content('buck', 'png', content)
+
+        # download_file
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            existing_path = pathlib.Path(tmp_dir) / 'existing'
+            s3.download_file('buck', 'png', str(existing_path))
+            self.assertEqual(existing_path.read_bytes(), content)
+
+            not_found_path = pathlib.Path(tmp_dir) / 'not-found'
+            with self.assertRaises(s3.exceptions.NoSuchKey):
+                s3.download_file('buck', 'png404', str(not_found_path))
+            assert not not_found_path.exists()
+
+        # download_fileobj
+        buf = io.BytesIO()
+        s3.download_fileobj(Bucket='buck', Key='png', Fileobj=buf)
+        self.assertEqual(buf.getvalue(), content)
+
+        not_found_buf = io.BytesIO()
+        with self.assertRaises(s3.exceptions.NoSuchKey):
+            s3.download_file('buck', 'png404', not_found_buf)
+        self.assertEqual(not_found_buf.getvalue(), b'')
+
+        # get_file
+        got = s3.get_object(Bucket='buck', Key='png')
+        self.assertEqual(got['Body'].read(), content)
+        self.assertEqual(got['ContentLength'], len(content))
+
+        with self.assertRaises(s3.exceptions.NoSuchKey):
+            s3.get_object(Bucket='buck', Key='png404')
+
+        # Mock function
+        self.assertEqual(s3.mock_get_content('buck', 'png'), content)


### PR DESCRIPTION
- Add `download_fileobject`
- Change function parameter names to match original boto3.
- Add tests covering the mock (there was a bug there)
