### PR TITLE
S3 mock closed files, too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Please take a look into the sources and tests for deeper informations.
 
 A simple mock for Boto3's S3 modules.
 
-* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L39-L156) - Simulates a boto3 S3 client object in tests
+* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L39-L160) - Simulates a boto3 S3 client object in tests
 
 #### bx_py_utils.test_utils.requests_mock_assertion
 

--- a/bx_py_utils/test_utils/mocks3.py
+++ b/bx_py_utils/test_utils/mocks3.py
@@ -87,6 +87,10 @@ class PseudoS3Client:
         if Callback:
             Callback(len(contents))
 
+        # boto3 closes file objects, see:
+        # https://github.com/boto/s3transfer/issues/80
+        Fileobj.close()
+
     # noqa non-standard variable names from https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.upload_file
     def upload_file(self, Filename, Bucket, Key, *, ExtraArgs=None, Callback=None, Config=None):
         contents = pathlib.Path(Filename).read_bytes()

--- a/bx_py_utils_tests/tests/test_test_utils_mocks3.py
+++ b/bx_py_utils_tests/tests/test_test_utils_mocks3.py
@@ -81,3 +81,11 @@ class S3MockTest(TestCase):
 
         # Mock function
         self.assertEqual(s3.mock_list_files('buck'), ['foo/aaa', 'foo/bar/baz', 'foo/zzz', 'xxx'])
+
+    def test_upload_fileobj_closed_file(self):
+        s3 = PseudoS3Client(init_buckets=('foo',))
+        with tempfile.TemporaryFile() as temp_file:
+            assert not temp_file.closed
+            s3.upload_fileobj(Fileobj=temp_file, Bucket='foo', Key='bar')
+            assert temp_file.closed
+


### PR DESCRIPTION
boto3 closes file objects, see:

https://github.com/boto/s3transfer/issues/80

Add this to our mock for `upload_fileobj()`, too.