### PR TITLE
debug_long_repr: Cut off long bytes

### DIFF
--- a/bx_py_utils/auto_doc.py
+++ b/bx_py_utils/auto_doc.py
@@ -87,7 +87,7 @@ def generate_modules_doc(modules, start_level=1, link_template=None):
 
     module_path = ModulePath()
 
-    module_names = extract.parse_specs(modules=modules)
+    module_names = extract.walk_specs(modules)
     parts = []
     for module_name in sorted(module_names):
         module_obj = extract.load_module(module_name)

--- a/bx_py_utils/test_utils/mocks3.py
+++ b/bx_py_utils/test_utils/mocks3.py
@@ -194,7 +194,7 @@ class PseudoS3Client:
                         content_repr = repr(content_str)
                 except ValueError:
                     # Binary content
-                    content_repr = repr(content)
+                    content_repr = repr(content[:max_string_length])
                     if len(content_repr) > max_string_length:
                         content_repr = content_repr[:max_string_length - 3][:-1] + '...'
 


### PR DESCRIPTION
In practice, when there are large files in the mocks3, printing the `repr` can take quite some time, on the order of 10s!

Instead, only extract the bytes we care, and calculate the repr of those, and then cut that off if necessary, which makes the whole task finish in <100ms.
