### PR TITLE
add query_selector param to assert_html_snapshot to limit snapshots to one or more specific html elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ Please take a look into the sources and tests for deeper informations.
 
 ### bx_py_utils.html_utils
 
+* [`ElementsNotFoundError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L44-L48) - Happens if requested HTML elements cannot be found
 * [`InvalidHtml()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L18-L41) - XMLSyntaxError with better error messages: used in validate_html()
-* [`pretty_format_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L69-L83) - Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
-* [`validate_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L44-L66) - Validate a HTML document via XMLParser (Needs 'lxml' package)
+* [`get_html_elements()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L97-L108) - Returns the selected HTML elements as string
+* [`pretty_format_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L87-L94) - Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
+* [`validate_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L51-L73) - Validate a HTML document via XMLParser (Needs 'lxml' package)
 
 #### bx_py_utils.humanize.pformat
 
@@ -147,7 +149,7 @@ A simple mock for Boto3's S3 modules.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L236-L274) - Assert "html" string via snapshot file with validate and pretty format
+* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L236-L283) - Assert "html" string via snapshot file with validate and pretty format
 * [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L196-L233) - Assert complex python objects vio PrettyPrinter() snapshot file.
 * [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L158-L193) - Assert given data serialized to JSON snapshot file.
 * [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L119-L155) - Assert "text" string via snapshot file

--- a/bx_py_utils/html_utils.py
+++ b/bx_py_utils/html_utils.py
@@ -41,6 +41,13 @@ class InvalidHtml(AssertionError):
         )
 
 
+class ElementsNotFoundError(AssertionError):
+    """
+    Happens if requested HTML elements cannot be found
+    """
+    pass
+
+
 def validate_html(data, **parser_kwargs):
     """
     Validate a HTML document via XMLParser (Needs 'lxml' package)
@@ -66,10 +73,7 @@ def validate_html(data, **parser_kwargs):
         raise InvalidHtml(data, err)
 
 
-def pretty_format_html(data, parser='html.parser', **bs_kwargs):
-    """
-    Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
-    """
+def get_beautiful_soup_instance(data, parser='html.parser', **bs_kwargs):
     assert isinstance(data, str)
 
     if BeautifulSoup is None:
@@ -77,7 +81,28 @@ def pretty_format_html(data, parser='html.parser', **bs_kwargs):
             'This feature needs "beautifulsoup4", please add it to you requirements'
         )
 
-    soup = BeautifulSoup(data, parser, **bs_kwargs)
+    return BeautifulSoup(data, parser, **bs_kwargs)
+
+
+def pretty_format_html(data, parser='html.parser', **bs_kwargs):
+    """
+    Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
+    """
+    soup = get_beautiful_soup_instance(data, parser, **bs_kwargs)
     return soup.prettify(
         formatter=None  # Do not perform any substitution
     )
+
+
+def get_html_elements(data, query_selector, parser='html.parser', **bs_kwargs):
+    """
+    Returns the selected HTML elements as string
+    """
+    soup = get_beautiful_soup_instance(data, parser, **bs_kwargs)
+    selected_elements = soup.select(query_selector)
+
+    if not selected_elements:
+        raise ElementsNotFoundError(
+            f'The query selector {query_selector} did not match any element in the HTML document')
+
+    return '\n'.join(str(tag) for tag in selected_elements)

--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -11,7 +11,7 @@ import re
 from collections import Counter
 from typing import Any, Callable, Optional, Union
 
-from bx_py_utils.html_utils import pretty_format_html, validate_html
+from bx_py_utils.html_utils import get_html_elements, pretty_format_html, validate_html
 
 
 try:
@@ -246,9 +246,13 @@ def assert_html_snapshot(
     validate_kwargs: dict = None,
     pretty_format: bool = True,
     pretty_kwargs: dict = None,
+    query_selector: str = None,
+    query_selector_kwargs: dict = None
 ):
     """
     Assert "html" string via snapshot file with validate and pretty format
+    Use "query_selector" to limit the snapshot to one or more elements. If the selector does not
+    find any elements, an ElementsNotFoundError is raised.
     """
     assert isinstance(got, str)
 
@@ -261,6 +265,11 @@ def assert_html_snapshot(
         if pretty_kwargs is None:
             pretty_kwargs = {}
         got = pretty_format_html(got, **pretty_kwargs)
+
+    if query_selector:
+        if query_selector_kwargs is None:
+            query_selector_kwargs = {}
+        got = get_html_elements(got, query_selector, **query_selector_kwargs)
 
     assert_text_snapshot(
         root_dir=root_dir,

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -10,7 +10,7 @@ import pytest
 
 import bx_py_utils
 from bx_py_utils import html_utils
-from bx_py_utils.path import assert_is_file
+from bx_py_utils.html_utils import ElementsNotFoundError
 from bx_py_utils.test_utils import snapshot
 from bx_py_utils.test_utils.assertion import pformat_ndiff, text_ndiff
 from bx_py_utils.test_utils.datetime import parse_dt
@@ -331,3 +331,23 @@ def test_assert_html_snapshot_without_lxml():
     assert str(cm.value) == (
         'This feature needs "lxml", please add it to you requirements'
     )
+
+def test_assert_html_snapshot_by_css_selector():
+    html = '''
+        <!DOCTYPE html> \r\n <html> \r\n  \r\n <head>
+         \r\n  \r\n <title \r\n >Page Title</title></head> \r\n  \r\n <body>
+        <h1>This is a Heading</h1> \r\n  \r\n
+        <p \r\n >This is a paragraph.</p> \r\n  \r\n
+        <div class="test-me"><b>some Content 1</b></div>
+        <div class="test-me"><i>some Content 2</i></div>
+        </body> \r\n  \r\n </html>
+    '''
+    assert_html_snapshot(got=html, query_selector='div.test-me')
+
+    try:
+        assert_html_snapshot(got=html, query_selector='div.not-found')
+        raise AssertionError('Expected ElementsNotFoundError, no Error was raised')
+    except ElementsNotFoundError:
+        pass
+    except Exception as err:
+        raise AssertionError('Expected ElementsNotFoundError, other Error was raised: ', err)

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot_assert_html_snapshot_by_css_selector_1.snapshot.html
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot_assert_html_snapshot_by_css_selector_1.snapshot.html
@@ -1,0 +1,10 @@
+<div class="test-me">
+<b>
+    some Content 1
+   </b>
+</div>
+<div class="test-me">
+<i>
+    some Content 2
+   </i>
+</div>


### PR DESCRIPTION
With this PR, you'll be able to perform HTML snapshot tests on specific HTML elements only (vs snapshot testing the whole HTML page).

Simply specify the query selector using:

    assert_html_snapshot(got=html, query_selector='div.test-me')