### PR TITLE
Add MockUUIDGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Please take a look into the sources and tests for deeper informations.
 
 * [`MockedBoto3Session()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mock_boto3session.py#L4-L46) - Mock for `boto3.session.Session()`
 
+#### bx_py_utils.test_utils.mock_uuid
+
+* [`MockUUIDGenerator()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mock_uuid.py#L5-L25) - Helper to mock `uuid.uuid4()` with reproducible results (e.g. for snapshot tests)
+
 #### bx_py_utils.test_utils.mocks3
 
 A simple mock for Boto3's S3 modules.

--- a/bx_py_utils/test_utils/mock_uuid.py
+++ b/bx_py_utils/test_utils/mock_uuid.py
@@ -1,0 +1,25 @@
+import uuid
+from unittest import mock
+
+
+class MockUUIDGenerator:
+    """ Helper to mock `uuid.uuid4()` with reproducible results (e.g. for snapshot tests) """
+
+    def __init__(self):
+        self.num = 0
+
+    def __call__(self):
+        self.num += 1
+        return uuid.UUID(f'89e6b14d-622a-409f-88de-{self.num:012d}')
+
+    @classmethod
+    def install(cls):
+        instance = MockUUIDGenerator()
+        return instance
+
+    def __enter__(self):
+        self._mock = mock.patch('uuid.uuid4', self)
+        self._mock.__enter__()
+
+    def __exit__(self, exc, value, tb):
+        self._mock.__exit__(exc, value, tb)

--- a/bx_py_utils_tests/tests/test_test_utils_mock_uuid.py
+++ b/bx_py_utils_tests/tests/test_test_utils_mock_uuid.py
@@ -1,0 +1,12 @@
+import uuid
+from unittest import TestCase
+
+from bx_py_utils.test_utils.mock_uuid import MockUUIDGenerator
+
+
+class UUIDMockTest(TestCase):
+    def test_basics(self):
+        with MockUUIDGenerator.install():
+            self.assertEqual(uuid.uuid4(), uuid.UUID('89e6b14d-622a-409f-88de-000000000001'))
+            self.assertEqual(uuid.uuid4(), uuid.UUID('89e6b14d-622a-409f-88de-000000000002'))
+            self.assertEqual(uuid.uuid4(), uuid.UUID('89e6b14d-622a-409f-88de-000000000003'))


### PR DESCRIPTION
This generator can be used to get the same UUIDs in every run, for example for a snapshot test.
