### PR TITLE
Enhance bx_py_utils.test_utils.mocks3.PseudoS3Client.download_fileobj()

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Please take a look into the sources and tests for deeper informations.
 
 A simple mock for Boto3's S3 modules.
 
-* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L60-L209) - Simulates a boto3 S3 client object in tests
+* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L60-L213) - Simulates a boto3 S3 client object in tests
 
 #### bx_py_utils.test_utils.requests_mock_assertion
 

--- a/bx_py_utils/test_utils/mocks3.py
+++ b/bx_py_utils/test_utils/mocks3.py
@@ -78,11 +78,15 @@ class PseudoS3Client:
             f.write(bucket[Key])
 
     # non-standard variable names for Boto3 compatibility
-    def download_fileobj(self, Bucket, Key, Fileobj):
+    def download_fileobj(self, Bucket, Key, Fileobj, ExtraArgs=None, Callback=None, Config=None):
         bucket = self.buckets[Bucket]
-        if Key not in bucket:
+        storage = getattr(bucket, 'bucket_storage', bucket)
+        if Key not in storage:
             raise self.exceptions.NoSuchKey(Key)
-        Fileobj.write(bucket[Key])
+        content = storage[Key]
+        Fileobj.write(content)
+        if Callback:
+            Callback(len(content))
 
     # non-standard variable names for Boto3 compatibility
     def get_object(self, *, Bucket, Key):

--- a/bx_py_utils_tests/tests/test_test_utils_mocks3.py
+++ b/bx_py_utils_tests/tests/test_test_utils_mocks3.py
@@ -39,9 +39,18 @@ class S3MockTest(TestCase):
             assert not not_found_path.exists()
 
         # download_fileobj
+        class Callback:
+            def __init__(self):
+                self.total_bytes = 0
+
+            def __call__(self, byte_count):
+                self.total_bytes += byte_count
+
+        callback = Callback()
         buf = io.BytesIO()
-        s3.download_fileobj(Bucket='buck', Key='png', Fileobj=buf)
+        s3.download_fileobj(Bucket='buck', Key='png', Fileobj=buf, Callback=callback)
         self.assertEqual(buf.getvalue(), content)
+        self.assertEqual(callback.total_bytes, len(content))
 
         not_found_buf = io.BytesIO()
         with self.assertRaises(s3.exceptions.NoSuchKey):


### PR DESCRIPTION
Support `Callback` and support passing all origin arguments.