### PR TITLE
Fix XSS vulnerability in assert_html_snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Please take a look into the sources and tests for deeper informations.
 
 * [`ElementsNotFoundError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L44-L48) - Happens if requested HTML elements cannot be found
 * [`InvalidHtml()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L18-L41) - XMLSyntaxError with better error messages: used in validate_html()
-* [`get_html_elements()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L97-L108) - Returns the selected HTML elements as string
-* [`pretty_format_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L87-L94) - Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
+* [`get_html_elements()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L95-L106) - Returns the selected HTML elements as string
+* [`pretty_format_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L87-L92) - Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
 * [`validate_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L51-L73) - Validate a HTML document via XMLParser (Needs 'lxml' package)
 
 #### bx_py_utils.humanize.pformat

--- a/bx_py_utils/html_utils.py
+++ b/bx_py_utils/html_utils.py
@@ -89,9 +89,7 @@ def pretty_format_html(data, parser='html.parser', **bs_kwargs):
     Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
     """
     soup = get_beautiful_soup_instance(data, parser, **bs_kwargs)
-    return soup.prettify(
-        formatter=None  # Do not perform any substitution
-    )
+    return soup.prettify()
 
 
 def get_html_elements(data, query_selector, parser='html.parser', **bs_kwargs):

--- a/bx_py_utils_tests/tests/test_html_utils.py
+++ b/bx_py_utils_tests/tests/test_html_utils.py
@@ -62,6 +62,14 @@ def test_pretty_format_html():
     ''')
     assert html == '<h1>\n X\n</h1>\n<p>\n <strong>\n  Test\n </strong>\n</p>\n'
 
+    assert pretty_format_html("<code>&lt;script&gt;alert('XSS')&lt;/script&gt;</code>") == (
+        '<code>\n' " &lt;script&gt;alert('XSS')&lt;/script&gt;\n" '</code>'
+    )
+
+    assert pretty_format_html('<p>&lt;XSS énc🕳d&#128065;ng&gt; a&#97;&#x61;</p>') == (
+        '<p>\n &lt;XSS énc🕳d👁ng&gt; aaa\n</p>'
+    )
+
     # Our helpful error message if requirements missing?
 
     with patch.object(html_utils, 'BeautifulSoup', None), \


### PR DESCRIPTION
We passed `formatter=None` to beautiful_soup.prettify in an effort to not mess with the input.
But this _MASSIVELY_ messes with the input and does not correctly escape it.
This could even lead to Cross-Site-Scripting (XSS) vulnerabilities! Fortunately this function is not used on user input, but still.

Add a test to ensure correct encoding.
