### PR TITLE
Add RISON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Please take a look into the sources and tests for deeper informations.
 
 * [`processify()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/processify.py#L12-L53) - Decorator to run a function as a process.
 
+### bx_py_utils.rison
+
+* [`rison_dumps()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/rison.py#L4-L31) - Encode as RISON, a URL-safe encoding format.
+
 ### bx_py_utils.stack_info
 
 * [`FrameNotFound()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L8-L13) - Base class for lookup errors.

--- a/bx_py_utils/rison.py
+++ b/bx_py_utils/rison.py
@@ -1,0 +1,31 @@
+import re
+
+
+def rison_dumps(obj):
+    """Encode as RISON, a URL-safe encoding format.
+    Decoder and spec can be found at https://github.com/Nanonid/rison .
+    """
+
+    if obj is True:
+        return '!t'
+    if obj is False:
+        return '!f'
+    if obj is None:
+        return '!n'
+
+    if isinstance(obj, str):
+        if re.match(r'^[a-zA-Z_][a-zA-Z0-9_]+$', obj):
+            return obj  # no quoting necessary!
+
+        return "'" + re.sub(r"([!'])", r'!\1', obj) + "'"
+
+    if isinstance(obj, dict):
+        return '(' + ','.join(rison_dumps(k) + ':' + rison_dumps(v) for k, v in obj.items()) + ')'
+
+    if isinstance(obj, (list, tuple)):
+        return '!(' + ','.join(rison_dumps(v) for v in obj) + ')'
+
+    if isinstance(obj, int):
+        return str(obj)
+
+    raise TypeError(f'Unsupported object {obj!r} of type {type(obj).__name__}')

--- a/bx_py_utils_tests/tests/test_rison.py
+++ b/bx_py_utils_tests/tests/test_rison.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+
+from bx_py_utils.rison import rison_dumps
+
+
+class RISONTest(TestCase):
+    def test_rison_dumps(self):
+        self.assertEqual(rison_dumps(True), '!t')
+        self.assertEqual(rison_dumps(False), '!f')
+        self.assertEqual(rison_dumps(None), '!n')
+        self.assertEqual(rison_dumps(None), '!n')
+        self.assertEqual(rison_dumps(''), "''")
+        self.assertEqual(rison_dumps('ab'), 'ab')  # no quoting necessary!
+        self.assertEqual(rison_dumps('a b'), '\'a b\'')
+        self.assertEqual(
+            rison_dumps('a\'b\\c"d!e!!f'), "'a!'b\\c\"d!!e!!!!f'"
+        )  # only ' and ! need to be escaped
+        self.assertEqual(rison_dumps([]), '!()')
+        self.assertEqual(rison_dumps({'x': 1, 'y z': [2, 3]}), "('x':1,'y z':!(2,3))")


### PR DESCRIPTION
RISON is used by the OpenSearch dashboard.

There is a public PyPi package for RISON, but it's unmaintained and not installable with a recent pipenv.
The language is sufficiently simple that we can just implement it.
