### PR TITLE
RISON: less quoting

### DIFF
--- a/bx_py_utils/rison.py
+++ b/bx_py_utils/rison.py
@@ -14,7 +14,7 @@ def rison_dumps(obj):
         return '!n'
 
     if isinstance(obj, str):
-        if re.match(r'^[a-zA-Z_][a-zA-Z0-9_]+$', obj):
+        if re.match(r'^[a-zA-Z_][-a-zA-Z0-9_]+$', obj):
             return obj  # no quoting necessary!
 
         return "'" + re.sub(r"([!'])", r'!\1', obj) + "'"

--- a/bx_py_utils_tests/tests/test_rison.py
+++ b/bx_py_utils_tests/tests/test_rison.py
@@ -11,6 +11,7 @@ class RISONTest(TestCase):
         self.assertEqual(rison_dumps(None), '!n')
         self.assertEqual(rison_dumps(''), "''")
         self.assertEqual(rison_dumps('ab'), 'ab')  # no quoting necessary!
+        self.assertEqual(rison_dumps('now-2d'), 'now-2d')  # no quoting here either!
         self.assertEqual(rison_dumps('a b'), '\'a b\'')
         self.assertEqual(
             rison_dumps('a\'b\\c"d!e!!f'), "'a!'b\\c\"d!!e!!!!f'"


### PR DESCRIPTION
Incredibly, `now-7d` does NOT to be quoted in RISON. Add this to make nicer URLs.
