### PR TITLE
Fix #157 and make "pdoc" optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Please take a look into the sources and tests for deeper informations.
 
 ### bx_py_utils.auto_doc
 
-* [`FnmatchExclude()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L176-L190) - Helper for auto doc `exclude_func` that exclude files via fnmatch pattern.
-* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L149-L173) - Check and update README file with generate_modules_doc()
-* [`assert_readme_block()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L116-L146) - Check and update README file: Asset that "text_block" is present between the markers.
-* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L36-L113) - Generate a list of function/class information via pdoc.
-* [`get_code_location()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L28-L33) - Return start and end line number for an object via inspect.
+* [`FnmatchExclude()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L185-L199) - Helper for auto doc `exclude_func` that exclude files via fnmatch pattern.
+* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L158-L182) - Check and update README file with generate_modules_doc()
+* [`assert_readme_block()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L125-L155) - Check and update README file: Asset that "text_block" is present between the markers.
+* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L42-L122) - Generate a list of function/class information via pdoc.
+* [`get_code_location()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L34-L39) - Return start and end line number for an object via inspect.
 
 #### bx_py_utils.aws.client_side_cert_manager
 

--- a/bx_py_utils/auto_doc.py
+++ b/bx_py_utils/auto_doc.py
@@ -4,8 +4,14 @@ import inspect
 import re
 from pathlib import Path
 
-from pdoc import extract
-from pdoc.doc import Module
+
+try:
+    from pdoc import extract
+    from pdoc.doc import Module
+except ImportError as err:
+    _pdoc_import_error = err
+else:
+    _pdoc_import_error = None
 
 from bx_py_utils.path import assert_is_file
 from bx_py_utils.test_utils.assertion import assert_text_equal
@@ -44,6 +50,9 @@ def generate_modules_doc(modules, exclude_func: callable = None, start_level=1, 
     """
     if link_template and 'lnum' in link_template:
         raise AssertionError('Please change "lnum" in "link_template" to {start}, {end}')
+
+    if _pdoc_import_error is not None:
+        raise ImportError(f'{_pdoc_import_error} (Hint: Install "pdoc" package)')
 
     def first_doc_line(doc_string):
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bx_py_utils"
-version = "74"
+version = "75"
 description = "Various Python utility functions"
 homepage = "https://github.com/boxine/bx_py_utils/"
 authors = [


### PR DESCRIPTION
`bx_py_utils.auto_doc.assert_readme_block()` is a nice helper that can be used independ of `pdoc`.
e.g.: https://github.com/jedie/manageprojects/pull/43