### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ mypy:  ## Run mypy
 safety:  ## Run https://github.com/pyupio/safety
 	poetry run safety check --full-report
 
-publish: ## Release new version to PyPi
+publish: install  ## Release new version to PyPi
 	poetry run publish
 
 clean: ## Remove created files from the test project


### PR DESCRIPTION
Call "install" before publishing, because the current version of the package should be installed, otherwise "poetry-publish" will bump the version, again.