### PR TITLE
NEW: Helper to add doctests into unittest by just adding a TestCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ Assert complex output via auto updated snapshot files with nice diff error messa
 
 #### bx_py_utils.test_utils.unittest_utils
 
-* [`assert_no_flat_tests_functions()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L8-L22) - Check if there exists normal test functions (That will not be executed by normal unittests)
+* [`BaseDocTests()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L31-L61) - Helper to include all doctests in unittests, without change unittest setup. Just add a normal TestCase.
+* [`assert_no_flat_tests_functions()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L14-L28) - Check if there exists normal test functions (That will not be executed by normal unittests)
 
 ### bx_py_utils.text_tools
 

--- a/bx_py_utils_tests/tests/test_doctests.py
+++ b/bx_py_utils_tests/tests/test_doctests.py
@@ -1,0 +1,7 @@
+import bx_py_utils
+from bx_py_utils.test_utils.unittest_utils import BaseDocTests
+
+
+class DocTests(BaseDocTests):
+    def test_doctests(self):
+        self.run_doctests(modules=(bx_py_utils,))


### PR DESCRIPTION
The "normal" way to add doctests to unittests is described here:

https://docs.python.org/3/library/doctest.html#unittest-api

But it's needed to change the unittest setup and how tests loaded. With the `BaseDocTests` it's just needed to ass another `TestCase` and you are done ;)

This will increase the number of tests from 88 to 167, because we have already many doctests and after replace pytests with unittests they was not tested. But hey, no changes needed, all doctests are still correct ;)