### PR TITLE
Check type annotations in tests via typeguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Please take a look into the sources and tests for deeper informations.
 
 ### bx_py_utils.auto_doc
 
-* [`FnmatchExclude()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L201-L210) - Helper for auto doc `exclude_func` that exclude files via fnmatch pattern.
-* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L172-L198) - Check and update README file with generate_modules_doc()
-* [`assert_readme_block()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L139-L169) - Check and update README file: Asset that "text_block" is present between the markers.
-* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L44-L136) - Generate a list of function/class information via pdoc.
-* [`get_code_location()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L36-L41) - Return start and end line number for an object via inspect.
+* [`FnmatchExclude()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L203-L212) - Helper for auto doc `exclude_func` that exclude files via fnmatch pattern.
+* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L174-L200) - Check and update README file with generate_modules_doc()
+* [`assert_readme_block()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L141-L171) - Check and update README file: Asset that "text_block" is present between the markers.
+* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L46-L138) - Generate a list of function/class information via pdoc.
+* [`get_code_location()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L38-L43) - Return start and end line number for an object via inspect.
 
 #### bx_py_utils.aws.client_side_cert_manager
 
@@ -51,8 +51,8 @@ Please take a look into the sources and tests for deeper informations.
 
 ### bx_py_utils.dict_utils
 
-* [`dict_get()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L4-L25) - nested dict `get()`
-* [`pluck()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L28-L40) - Extract values from a dict, if they are present
+* [`dict_get()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L6-L27) - nested dict `get()`
+* [`pluck()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L30-L42) - Extract values from a dict, if they are present
 
 ### bx_py_utils.doc_write
 
@@ -70,14 +70,14 @@ Doc-Write, see: https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/do
 
 ### bx_py_utils.file_utils
 
-* [`EmptyFileError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L17-L21) - Will be raised from get_and_assert_file_size() if a 0-bytes file was found.
-* [`FileError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L9-L14) - Base error class for all 'file_utils' exceptions.
+* [`EmptyFileError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L18-L21) - Will be raised from get_and_assert_file_size() if a 0-bytes file was found.
+* [`FileError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L12-L15) - Base error class for all 'file_utils' exceptions.
 * [`FileHasher()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L79-L104) - Context Manager for generate different hashes from file content while processing a file.
 * [`FileSizeError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L24-L38) - File size is not the same as the expected size.
 * [`NamedTemporaryFile2()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L53-L76) - Generates a temp file with the given filename **without** any random name sequence.
-* [`OverlongFilenameError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L188-L193) - cut_filename() error: The file name can not be shortened, because sterm is to short.
+* [`OverlongFilenameError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L188-L191) - cut_filename() error: The file name can not be shortened, because sterm is to short.
 * [`TempFileHasher()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L107-L178) - File like context manager that combines NamedTemporaryFile2 and FileHasher.
-* [`cut_filename()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L196-L236) - Short the file name (and keep the last suffix). Raise OverlongFilenameError if it can't fit.
+* [`cut_filename()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L194-L234) - Short the file name (and keep the last suffix). Raise OverlongFilenameError if it can't fit.
 * [`get_and_assert_file_size()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L41-L50) - Check file size of given file object. Raise EmptyFileError for empty files or return size
 * [`safe_filename()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L181-L185) - Makes an arbitrary input suitable to be used as a filename.
 
@@ -140,12 +140,12 @@ Doc-Write, see: https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/do
 
 ### bx_py_utils.string_utils
 
-* [`compare_sentences()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L67-L90) - Calculates the Levenshtein distance between text1 and text2. With filter functionality.
-* [`ensure_lf()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L106-L116) - Replace line endings to unix-style.
-* [`get_words()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L40-L64) - Extract words from a text. With filter functionality.
-* [`levenshtein_distance()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L8-L37) - Calculates the Levenshtein distance between two strings.
-* [`startswith_prefixes()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L119-L135) - >>> startswith_prefixes('foobar', prefixes=('foo','bar'))
-* [`uuid_from_text()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L93-L103) - Generate a UUID instance from the given text in a determinism may via SHA224 hash.
+* [`compare_sentences()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L68-L89) - Calculates the Levenshtein distance between text1 and text2. With filter functionality.
+* [`ensure_lf()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L105-L115) - Replace line endings to unix-style.
+* [`get_words()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L41-L65) - Extract words from a text. With filter functionality.
+* [`levenshtein_distance()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L9-L38) - Calculates the Levenshtein distance between two strings.
+* [`startswith_prefixes()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L118-L134) - >>> startswith_prefixes('foobar', prefixes=('foo','bar'))
+* [`uuid_from_text()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/string_utils.py#L92-L102) - Generate a UUID instance from the given text in a determinism may via SHA224 hash.
 
 #### bx_py_utils.test_utils.assertion
 
@@ -211,13 +211,13 @@ A simple mock for Boto3's S3 modules.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`SnapshotChanged()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L47-L48) - Assertion failed.
-* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L363-L404) - Assert binary data via snapshot file
-* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L298-L347) - Assert "html" string via snapshot file with validate and pretty format
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L249-L295) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L199-L246) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L151-L196) - Assert "text" string via snapshot file
-* [`get_snapshot_file()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L121-L148) - Generate a file path use stack information to fill not provided path components.
+* [`SnapshotChanged()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L50-L51) - Assertion failed.
+* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L366-L407) - Assert binary data via snapshot file
+* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L301-L350) - Assert "html" string via snapshot file with validate and pretty format
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L252-L298) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L202-L249) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L154-L199) - Assert "text" string via snapshot file
+* [`get_snapshot_file()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L124-L151) - Generate a file path use stack information to fill not provided path components.
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils/auto_doc.py
+++ b/bx_py_utils/auto_doc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 import inspect
 import re
@@ -177,7 +179,7 @@ def assert_readme(
     start_marker_line: str = '[comment]: <> (✂✂✂ auto generated start ✂✂✂)',
     end_marker_line: str = '[comment]: <> (✂✂✂ auto generated end ✂✂✂)',
     start_level: int = 1,
-    link_template: str = None,
+    link_template: str | None = None,
 ):
     """
     Check and update README file with generate_modules_doc()

--- a/bx_py_utils/dict_utils.py
+++ b/bx_py_utils/dict_utils.py
@@ -1,7 +1,9 @@
-from typing import Iterable
+from __future__ import annotations
+
+from collections.abc import Iterable
 
 
-def dict_get(item, *keys):
+def dict_get(item, *keys) -> None | bool | str | dict | list:
     """
     nested dict `get()`
 

--- a/bx_py_utils/file_utils.py
+++ b/bx_py_utils/file_utils.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import hashlib
 import io
 import re
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
-from typing import BinaryIO, Iterable
+from typing import BinaryIO
 
 
 class FileError(AssertionError):
@@ -11,14 +14,11 @@ class FileError(AssertionError):
     Base error class for all 'file_utils' exceptions.
     """
 
-    pass
-
 
 class EmptyFileError(FileError):
     """
     Will be raised from get_and_assert_file_size() if a 0-bytes file was found.
     """
-    pass
 
 
 class FileSizeError(FileError):
@@ -84,7 +84,7 @@ class FileHasher:
 
     DEFAULT_HASH_NAMES = ('md5', 'sha1', 'sha3_224')
 
-    def __init__(self, hash_names: Iterable = None):
+    def __init__(self, hash_names: Iterable | None = None):
         hash_names = hash_names or self.DEFAULT_HASH_NAMES
         self.hash = {hash_name: hashlib.new(hash_name) for hash_name in hash_names}
         self.bytes_processed = 0
@@ -113,7 +113,7 @@ class TempFileHasher:
     def __init__(
         self,
         file_name: str,
-        hash_names: Iterable = None,
+        hash_names: Iterable | None = None,
         avoid_empty_files=True,
         expected_files_size=None,
     ):
@@ -189,8 +189,6 @@ class OverlongFilenameError(AssertionError):
     """
     cut_filename() error: The file name can not be shortened, because sterm is to short.
     """
-
-    pass
 
 
 def cut_filename(file_name: str, max_length: int, min_name_len: int = 1) -> str:

--- a/bx_py_utils/pyproject_toml.py
+++ b/bx_py_utils/pyproject_toml.py
@@ -14,7 +14,7 @@ except ImportError:
         raise ImportError(f'Please add "tomli" to your dev-dependencies! Origin error: {err}')
 
 
-def get_pyproject_config(section: tuple[str, ...], base_path: Path | None = None) -> dict | None:
+def get_pyproject_config(section: tuple[str, ...], base_path: Path | None = None) -> None | bool | str | dict | list:
     """
     Get a config section from "pyproject.toml". The path can be optional specify.
     Section is used to get the nested information, e.g.:

--- a/bx_py_utils/string_utils.py
+++ b/bx_py_utils/string_utils.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import hashlib
 import re
 import unicodedata
-from typing import Union
 from uuid import UUID
 
 
@@ -64,9 +65,7 @@ def get_words(text, min_word_length=0, ignore_words=(), to_lower=True):
     return words
 
 
-def compare_sentences(
-    text1, text2, min_word_length=4, ignore_words=(), compare_lower=True
-) -> Union[None, int]:
+def compare_sentences(text1, text2, min_word_length=4, ignore_words=(), compare_lower=True) -> None | int:
     """
     Calculates the Levenshtein distance between text1 and text2. With filter functionality.
     But split to words and ignore special characters.
@@ -103,7 +102,7 @@ def uuid_from_text(text: str) -> UUID:
     return uuid
 
 
-def ensure_lf(text: str) -> str:
+def ensure_lf(text: str | None) -> str | None:
     """
     Replace line endings to unix-style.
 
@@ -116,7 +115,7 @@ def ensure_lf(text: str) -> str:
     return text
 
 
-def startswith_prefixes(text: str, prefixes: tuple[str, ...]) -> bool:
+def startswith_prefixes(text: str | None, prefixes: tuple[str, ...]) -> bool:
     """
     >>> startswith_prefixes('foobar', prefixes=('foo','bar'))
     True

--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -3,6 +3,9 @@
 
     To update all snapshot files, run your tests with RAISE_SNAPSHOT_ERRORS=0 in environment.
 """
+
+from __future__ import annotations
+
 import hashlib
 import json
 import os
@@ -10,7 +13,7 @@ import pathlib
 import pprint
 import re
 from collections import Counter
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 from bx_py_utils.html_utils import get_html_elements, pretty_format_html, validate_html
 
@@ -59,10 +62,10 @@ def _write_json(obj, snapshot_file):
 
 def _get_caller_names(
     *,
-    root_dir: Union[pathlib.Path, str] = None,
-    snapshot_name: str = None,
-    name_suffix: str = None,
-    self_file_path: Union[pathlib.Path, str] = None,
+    root_dir: pathlib.Path | str | None = None,
+    snapshot_name: str | None = None,
+    name_suffix: str | None = None,
+    self_file_path: pathlib.Path | str | None = None,
     extension_prefix: str = '.snapshot',
 ):
     """
@@ -120,11 +123,11 @@ def _get_caller_names(
 
 def get_snapshot_file(
     *,
-    root_dir: Union[pathlib.Path, str] = None,
-    snapshot_name: str = None,
-    name_suffix: str = None,
-    extension: str = None,
-    self_file_path: Union[pathlib.Path, str] = None,
+    root_dir: pathlib.Path | str | None = None,
+    snapshot_name: str | None = None,
+    name_suffix: str | None = None,
+    extension: str | None = None,
+    self_file_path: pathlib.Path | str | None = None,
     extension_prefix: str = '.snapshot',
 ) -> pathlib.Path:
     """
@@ -149,15 +152,15 @@ def get_snapshot_file(
 
 
 def assert_text_snapshot(
-    root_dir: Union[pathlib.Path, str] = None,
-    snapshot_name: str = None,
-    got: str = None,
-    name_suffix: str = None,
+    root_dir: pathlib.Path | str | None = None,
+    snapshot_name: str | None = None,
+    got: str | None = None,
+    name_suffix: str | None = None,
     extension: str = '.txt',
     fromfile: str = 'got',
     tofile: str = 'expected',
     diff_func: Callable = text_unified_diff,
-    self_file_path: Union[pathlib.Path, str] = None,
+    self_file_path: pathlib.Path | str | None = None,
 ):
     """
     Assert "text" string via snapshot file
@@ -197,15 +200,15 @@ def assert_text_snapshot(
 
 
 def assert_snapshot(
-    root_dir: Union[pathlib.Path, str] = None,
-    snapshot_name: str = None,
-    got: Optional[Union[dict, list]] = None,
-    name_suffix: str = None,
+    root_dir: pathlib.Path | str | None = None,
+    snapshot_name: str | None = None,
+    got: dict | list | None = None,
+    name_suffix: str | None = None,
     extension: str = '.json',
     fromfile: str = 'got',
     tofile: str = 'expected',
     diff_func: Callable = pformat_unified_diff,
-    self_file_path: Union[pathlib.Path, str] = None,
+    self_file_path: pathlib.Path | str | None = None,
 ):
     """
     Assert given data serialized to JSON snapshot file.
@@ -247,15 +250,15 @@ def assert_snapshot(
 
 
 def assert_py_snapshot(
-    root_dir: Union[pathlib.Path, str] = None,
-    snapshot_name: str = None,
+    root_dir: pathlib.Path | str | None = None,
+    snapshot_name: str | None = None,
     got: Any = None,
-    name_suffix: str = None,
+    name_suffix: str | None = None,
     extension: str = '.txt',
     fromfile: str = 'got',
     tofile: str = 'expected',
     diff_func: Callable = _unified_diff,
-    self_file_path: Union[pathlib.Path, str] = None,
+    self_file_path: pathlib.Path | str | None = None,
 ):
     """
     Assert complex python objects vio PrettyPrinter() snapshot file.
@@ -296,21 +299,21 @@ def assert_py_snapshot(
 
 
 def assert_html_snapshot(
-    root_dir: Union[pathlib.Path, str] = None,
-    snapshot_name: str = None,
-    got: str = None,
-    name_suffix: str = None,
+    root_dir: pathlib.Path | str | None = None,
+    snapshot_name: str | None = None,
+    got: str | None = None,
+    name_suffix: str | None = None,
     extension: str = '.html',
     fromfile: str = 'got',
     tofile: str = 'expected',
     diff_func: Callable = text_unified_diff,
-    self_file_path: Union[pathlib.Path, str] = None,
+    self_file_path: pathlib.Path | str | None = None,
     validate: bool = True,
-    validate_kwargs: dict = None,
+    validate_kwargs: dict | None = None,
     pretty_format: bool = True,
-    pretty_kwargs: dict = None,
-    query_selector: str = None,
-    query_selector_kwargs: dict = None
+    pretty_kwargs: dict | None = None,
+    query_selector: str | None = None,
+    query_selector_kwargs: dict | None = None,
 ):
     """
     Assert "html" string via snapshot file with validate and pretty format
@@ -361,15 +364,15 @@ def binary_diff(got, expected, fromfile, tofile):
 
 
 def assert_binary_snapshot(
-    root_dir: Union[pathlib.Path, str] = None,
-    snapshot_name: str = None,
+    root_dir: pathlib.Path | str | None = None,
+    snapshot_name: str | None = None,
     got: bytes = None,
-    name_suffix: str = None,
+    name_suffix: str | None = None,
     extension: str = '.bin',
     fromfile: str = 'got',
     tofile: str = 'expected',
     diff_func: Callable = binary_diff,
-    self_file_path: Union[pathlib.Path, str] = None,
+    self_file_path: pathlib.Path | str | None = None,
 ):
     """
     Assert binary data via snapshot file

--- a/bx_py_utils_tests/tests/__init__.py
+++ b/bx_py_utils_tests/tests/__init__.py
@@ -1,0 +1,32 @@
+import os
+import unittest.util
+from pathlib import Path
+
+from typeguard import install_import_hook
+
+
+# Check type annotations via typeguard in all tests:
+install_import_hook(packages=('bx_py_utils', 'bx_py_utils_tests'))
+
+
+def pre_configure_tests() -> None:
+    print(f'Configure unittests via "load_tests Protocol" from {Path(__file__).relative_to(Path.cwd())}')
+
+    # Hacky way to display more "assert"-Context in failing tests:
+    _MIN_MAX_DIFF = unittest.util._MAX_LENGTH - unittest.util._MIN_DIFF_LEN
+    unittest.util._MAX_LENGTH = int(os.environ.get('UNITTEST_MAX_LENGTH', 300))
+    unittest.util._MIN_DIFF_LEN = unittest.util._MAX_LENGTH - _MIN_MAX_DIFF
+
+    # Deny any request via docket/urllib3 because tests they should mock all requests:
+    from bx_py_utils.test_utils.deny_requests import deny_any_real_request
+
+    deny_any_real_request()
+
+
+def load_tests(loader, tests, pattern):
+    """
+    Use unittest "load_tests Protocol" as a hook to setup test environment before running tests.
+    https://docs.python.org/3/library/unittest.html#load-tests-protocol
+    """
+    pre_configure_tests()
+    return loader.discover(start_dir=Path(__file__).parent, pattern=pattern)

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -7,6 +7,8 @@ from unittest import TestCase
 from unittest.mock import patch
 from uuid import UUID
 
+import typeguard
+
 import bx_py_utils
 from bx_py_utils import html_utils
 from bx_py_utils.environ import OverrideEnviron
@@ -95,8 +97,12 @@ class SnapshotTestCase(TestCase):
             )
 
             # invalid type
-            with self.assertRaises(AssertionError) as exc_info:
-                assert_snapshot(tmp_dir, 'invalid_type', {1, 2})
+            with self.assertRaises(AssertionError) as exc_info, typeguard.suppress_type_checks():
+                assert_snapshot(
+                    tmp_dir,
+                    'invalid_type',
+                    got={1, 2},  # noqa - set() is not allowed!
+                )
             self.assertEqual(
                 str(exc_info.exception),
                 'Not JSON-serializable: {1, 2} is not a dict or list, but a set',

--- a/poetry.lock
+++ b/poetry.lock
@@ -1881,6 +1881,25 @@ rich = ">=12.0.0"
 urllib3 = ">=1.26.0"
 
 [[package]]
+name = "typeguard"
+version = "4.1.5"
+description = "Run-time type checker for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "typeguard-4.1.5-py3-none-any.whl", hash = "sha256:8923e55f8873caec136c892c3bed1f676eae7be57cdb94819281b3d3bc9c0953"},
+    {file = "typeguard-4.1.5.tar.gz", hash = "sha256:ea0a113bbc111bcffc90789ebb215625c963411f7096a7e9062d4e4630c155fd"},
+]
+
+[package.dependencies]
+importlib-metadata = {version = ">=3.6", markers = "python_version < \"3.10\""}
+typing-extensions = {version = ">=4.7.0", markers = "python_version < \"3.12\""}
+
+[package.extras]
+doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=7)", "mypy (>=1.2.0)", "pytest (>=7)"]
+
+[[package]]
 name = "types-python-dateutil"
 version = "2.8.19.20240106"
 description = "Typing stubs for python-dateutil"
@@ -1973,4 +1992,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "3e44b887d5d7f2a704a5977c74e3376d44ce32dd48e5aa485c9eccc2f4f41857"
+content-hash = "bc80684222d01dedf7a219c8bb35e8fdebfbe6f890be5588b99c895c0f293921"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ beautifulsoup4 = "*"
 lxml = "*"
 pdoc = "*"  # https://pdoc.dev/
 
+typeguard = "*"  # https://github.com/agronholm/typeguard/
+
 # https://github.com/akaihola/darker
 # https://github.com/ikamensh/flynt
 # https://github.com/pycqa/isort


### PR DESCRIPTION
Activate typeguard by `install_import_hook()` in `bx_py_utils_tests/tests/__init__.py` so it's
activated for unittests, only.

Fix some wrong typehints. Mainly missing ` | None` in optional keyword arguments.