### PR TITLE
Enhance BaseDocTests and add optional argument to exclude file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Please take a look into the sources and tests for deeper informations.
 
 ### bx_py_utils.auto_doc
 
-* [`FnmatchExclude()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L185-L199) - Helper for auto doc `exclude_func` that exclude files via fnmatch pattern.
-* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L158-L182) - Check and update README file with generate_modules_doc()
-* [`assert_readme_block()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L125-L155) - Check and update README file: Asset that "text_block" is present between the markers.
-* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L42-L122) - Generate a list of function/class information via pdoc.
-* [`get_code_location()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L34-L39) - Return start and end line number for an object via inspect.
+* [`FnmatchExclude()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L186-L195) - Helper for auto doc `exclude_func` that exclude files via fnmatch pattern.
+* [`assert_readme()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L159-L183) - Check and update README file with generate_modules_doc()
+* [`assert_readme_block()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L126-L156) - Check and update README file: Asset that "text_block" is present between the markers.
+* [`generate_modules_doc()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L43-L123) - Generate a list of function/class information via pdoc.
+* [`get_code_location()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/auto_doc.py#L35-L40) - Return start and end line number for an object via inspect.
 
 #### bx_py_utils.aws.client_side_cert_manager
 
@@ -75,6 +75,10 @@ Please take a look into the sources and tests for deeper informations.
 * [`cut_filename()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L196-L236) - Short the file name (and keep the last suffix). Raise OverlongFilenameError if it can't fit.
 * [`get_and_assert_file_size()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L41-L50) - Check file size of given file object. Raise EmptyFileError for empty files or return size
 * [`safe_filename()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/file_utils.py#L181-L185) - Makes an arbitrary input suitable to be used as a filename.
+
+### bx_py_utils.filename_matcher
+
+* [`filename_matcher()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/filename_matcher.py#L6-L22) - Enhance fnmatch that accept a list of patterns.
 
 ### bx_py_utils.graphql_introspection
 
@@ -202,8 +206,8 @@ Assert complex output via auto updated snapshot files with nice diff error messa
 
 #### bx_py_utils.test_utils.unittest_utils
 
-* [`BaseDocTests()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L31-L61) - Helper to include all doctests in unittests, without change unittest setup. Just add a normal TestCase.
-* [`assert_no_flat_tests_functions()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L14-L28) - Check if there exists normal test functions (That will not be executed by normal unittests)
+* [`BaseDocTests()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L32-L71) - Helper to include all doctests in unittests, without change unittest setup. Just add a normal TestCase.
+* [`assert_no_flat_tests_functions()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L15-L29) - Check if there exists normal test functions (That will not be executed by normal unittests)
 
 ### bx_py_utils.text_tools
 

--- a/bx_py_utils/auto_doc.py
+++ b/bx_py_utils/auto_doc.py
@@ -1,8 +1,9 @@
-import fnmatch
 import importlib
 import inspect
 import re
 from pathlib import Path
+
+from bx_py_utils.filename_matcher import filename_matcher
 
 
 try:
@@ -191,9 +192,4 @@ class FnmatchExclude:
         self.patterns = patterns
 
     def __call__(self, file_path: str) -> bool:
-        assert isinstance(file_path, str)
-        for pattern in self.patterns:
-            assert isinstance(pattern, str)
-            if fnmatch.fnmatch(file_path, pattern):
-                return False  # ignore this file for auto docs
-        return True  # include this file
+        return not filename_matcher(patterns=self.patterns, file_path=file_path)

--- a/bx_py_utils/filename_matcher.py
+++ b/bx_py_utils/filename_matcher.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import fnmatch
+
+
+def filename_matcher(*, patterns: list | tuple, file_path: str) -> bool:
+    """
+    Enhance fnmatch that accept a list of patterns.
+
+    >>> filename_matcher(patterns=['*bar.py'], file_path='/bar/test.py')
+    False
+    >>> filename_matcher(patterns=['*bar.py'], file_path='/foo/a-match-bar.py')
+    True
+    """
+    assert isinstance(file_path, str), f'No string: {file_path=}'
+
+    for pattern in patterns:
+        assert isinstance(pattern, str), f'No string: {pattern=}'
+        if fnmatch.fnmatch(file_path, pattern):
+            return True  # File path match one of the pattern
+
+    return False  # File path doesn't match any pattern

--- a/bx_py_utils/test_utils/unittest_utils.py
+++ b/bx_py_utils/test_utils/unittest_utils.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 from unittest import TestCase
 
+from bx_py_utils.filename_matcher import filename_matcher
 from bx_py_utils.path import assert_is_dir
 from bx_py_utils.test_utils.redirect import RedirectOut
 
@@ -40,10 +41,11 @@ class BaseDocTests(TestCase):
             def test_doctests(self):
                 self.run_doctests(
                     modules=(foo1, bar2),  # Add your modules that should be scanned recursively for doctests
+                    excludes=('**/settings', '**/migrations'),  # (Optional) exclude some file paths
                 )
     """
 
-    def run_doctests(self, modules: tuple, verbose=False, recurse=True, exclude_empty=True):
+    def run_doctests(self, modules: tuple, verbose=False, recurse=True, exclude_empty=True, excludes=None):
         runner = doctest.DocTestRunner(verbose=verbose)
         finder = doctest.DocTestFinder(verbose=verbose, recurse=recurse, exclude_empty=exclude_empty)
 
@@ -51,10 +53,18 @@ class BaseDocTests(TestCase):
             self.assertTrue(inspect.ismodule(module), f'Not a module: {module}')
 
             for info in pkgutil.walk_packages(module.__path__, module.__name__ + '.'):
+                if excludes:
+                    module_finder = info.module_finder
+                    module_path = module_finder.path
+                    if not filename_matcher(patterns=excludes, file_path=module_path):
+                        with self.subTest(info.name):
+                            self.skipTest(reason=f'Skip DocTest in: {module_path}')
+                        continue
+
                 module = importlib.import_module(info.name)
                 tests: list[doctest.DocTest] = finder.find(obj=module)
                 for test in tests:
-                    with self.subTest(info.name):
+                    with self.subTest(test.name):
                         with RedirectOut() as buffer:
                             result: doctest.TestResults = runner.run(test)
                         if result.failed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bx_py_utils"
-version = "78"
+version = "79"
 description = "Various Python utility functions"
 homepage = "https://github.com/boxine/bx_py_utils/"
 authors = [


### PR DESCRIPTION
Refactor FnmatchExclude and use a flat function for the matching: For the "auto_doc" is still a callable usefull, but for doc test we can just use a normal function.

Enhance also the `subTest` names in DocTest to the real function package dot-name.