### PR TITLE
Bugfix run_doctests and `excludes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,8 @@ Assert complex output via auto updated snapshot files with nice diff error messa
 
 #### bx_py_utils.test_utils.unittest_utils
 
-* [`BaseDocTests()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L32-L71) - Helper to include all doctests in unittests, without change unittest setup. Just add a normal TestCase.
-* [`assert_no_flat_tests_functions()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L15-L29) - Check if there exists normal test functions (That will not be executed by normal unittests)
+* [`BaseDocTests()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L40-L87) - Helper to include all doctests in unittests, without change unittest setup. Just add a normal TestCase.
+* [`assert_no_flat_tests_functions()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/unittest_utils.py#L16-L30) - Check if there exists normal test functions (That will not be executed by normal unittests)
 
 ### bx_py_utils.text_tools
 

--- a/bx_py_utils_tests/tests/doctest_skip.py
+++ b/bx_py_utils_tests/tests/doctest_skip.py
@@ -1,0 +1,10 @@
+def failed_doc_test():
+    """
+    This is a DocTest that will fail:
+
+    >>> failed_doc_test()
+    123
+
+    But the real test is that the `excludes` argument ot run_doctests() will work.
+    """
+    pass

--- a/bx_py_utils_tests/tests/test_auto_doc.py
+++ b/bx_py_utils_tests/tests/test_auto_doc.py
@@ -7,7 +7,7 @@ from bx_py_utils.auto_doc import assert_readme_block
 from bx_py_utils.test_utils.assertion import assert_text_equal
 
 
-class AudoDocTestCase(TestCase):
+class AutoDocTestCase(TestCase):
     def test_assert_readme_block(self):
         text_block = inspect.cleandoc(
             '''

--- a/bx_py_utils_tests/tests/test_doctests.py
+++ b/bx_py_utils_tests/tests/test_doctests.py
@@ -1,7 +1,15 @@
 import bx_py_utils
-from bx_py_utils.test_utils.unittest_utils import BaseDocTests
+import bx_py_utils_tests
+from bx_py_utils.test_utils.unittest_utils import BaseDocTests, DocTestResults
 
 
 class DocTests(BaseDocTests):
     def test_doctests(self):
-        self.run_doctests(modules=(bx_py_utils,))
+        results = self.run_doctests(
+            modules=(bx_py_utils, bx_py_utils_tests),
+            excludes=('**/bx_py_utils_tests/tests/doctest_skip.py',),
+        )
+        self.assertIsInstance(results, DocTestResults)
+        self.assertGreaterEqual(results.passed, 80)
+        self.assertEqual(results.skipped, 1)  # doctest_skip.py
+        self.assertLessEqual(results.failed, 0)  # Failing test in doctest_skip.py skipped?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bx_py_utils"
-version = "79"
+version = "80"
 description = "Various Python utility functions"
 homepage = "https://github.com/boxine/bx_py_utils/"
 authors = [


### PR DESCRIPTION
The `filename_matcher()` was used the wrong way around.

Enhance also the implementation and use `DocTest.filename` for exclusion. So it's the complete path including the file name, too.

Bugfix also typo: `AudoDocTestCase` -> `AutoDocTestCase`, too.