### PR TITLE
state the snapshot name or file when a snapshot's content changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ Please take a look into the sources and tests for deeper informations.
 
 #### bx_py_utils.test_utils.assertion
 
-* [`assert_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L63-L76) - Check if the two objects are the same. Display a nice diff, using `pformat()`
-* [`assert_text_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L79-L94) - Check if the two text strings are the same. Display a error message with a diff.
-* [`pformat_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L15-L25) - Generate a `ndiff` from two objects, using `pformat()`
-* [`pformat_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L46-L60) - Generate a unified diff from two objects, using `pformat()`
-* [`text_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L7-L12) - Generate a `ndiff` between two text strings.
-* [`text_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L39-L43) - Generate a unified diff between two text strings.
+* [`assert_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L64-L77) - Check if the two objects are the same. Display a nice diff, using `pformat()`
+* [`assert_text_equal()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L80-L95) - Check if the two text strings are the same. Display an error message with a diff.
+* [`pformat_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L16-L26) - Generate a `ndiff` from two objects, using `pformat()`
+* [`pformat_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L47-L61) - Generate a unified diff from two objects, using `pformat()`
+* [`text_ndiff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L8-L13) - Generate a `ndiff` between two text strings.
+* [`text_unified_diff()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/assertion.py#L40-L44) - Generate a unified diff between two text strings.
 
 #### bx_py_utils.test_utils.context_managers
 
@@ -194,11 +194,12 @@ A simple mock for Boto3's S3 modules.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L344-L383) - Assert binary data via snapshot file
-* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L279-L328) - Assert "html" string via snapshot file with validate and pretty format
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L232-L276) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L184-L229) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L138-L181) - Assert "text" string via snapshot file
+* [`SnapshotChanged()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L47-L48) - Assertion failed.
+* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L354-L395) - Assert binary data via snapshot file
+* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L289-L338) - Assert "html" string via snapshot file with validate and pretty format
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L240-L286) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L190-L237) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L142-L187) - Assert "text" string via snapshot file
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils/test_utils/assertion.py
+++ b/bx_py_utils/test_utils/assertion.py
@@ -1,5 +1,6 @@
 import difflib
 import pprint
+from typing import Any, Type
 
 from bx_py_utils.humanize.pformat import pformat
 
@@ -61,34 +62,34 @@ def pformat_unified_diff(obj1, obj2, fromfile: str = 'got', tofile: str = 'expec
 
 
 def assert_equal(
-        obj1,
-        obj2,
-        msg=None,
-        fromfile: str = 'got',
-        tofile: str = 'expected',
-        diff_func=pformat_unified_diff):
+    obj1,
+    obj2,
+    msg: Any = 'Objects are not equal:',
+    fromfile: str = 'got',
+    tofile: str = 'expected',
+    diff_func=pformat_unified_diff,
+    raise_cls: Type[Exception] = AssertionError,
+):
     """
     Check if the two objects are the same. Display a nice diff, using `pformat()`
     """
     if obj1 != obj2:
-        if not msg:
-            msg = 'Objects are not equal:'
-        raise AssertionError(f'{msg}\n{diff_func(obj1,obj2, fromfile=fromfile, tofile=tofile)}')
+        raise raise_cls(f'{msg}\n{diff_func(obj1,obj2, fromfile=fromfile, tofile=tofile)}')
 
 
 def assert_text_equal(
-        txt1,
-        txt2,
-        msg=None,
-        fromfile: str = 'got',
-        tofile: str = 'expected',
-        diff_func=text_unified_diff):
+    txt1,
+    txt2,
+    msg: Any = 'Text not equal:',
+    fromfile: str = 'got',
+    tofile: str = 'expected',
+    diff_func=text_unified_diff,
+    raise_cls: Type[Exception] = AssertionError,
+):
     """
-    Check if the two text strings are the same. Display a error message with a diff.
+    Check if the two text strings are the same. Display an error message with a diff.
     """
     assert isinstance(txt1, str)
     assert isinstance(txt2, str)
     if txt1 != txt2:
-        if not msg:
-            msg = 'Text not equal:'
-        raise AssertionError(f'{msg}\n{diff_func(txt1, txt2, fromfile=fromfile, tofile=tofile)}')
+        raise raise_cls(f'{msg}\n{diff_func(txt1, txt2, fromfile=fromfile, tofile=tofile)}')

--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -44,6 +44,10 @@ _AUTO_SNAPSHOT_NAME_COUNTER = Counter()
 _UNIFY_NEWLINES_RE = r'\r?\n'
 
 
+class SnapshotChanged(AssertionError):
+    pass
+
+
 def raise_snapshot_errors():
     return os.environ.get('RAISE_SNAPSHOT_ERRORS') not in ('0', 'false')
 
@@ -177,7 +181,9 @@ def assert_text_snapshot(
             assert_text_equal(
                 got, expected,
                 fromfile=fromfile, tofile=tofile,
-                diff_func=diff_func
+                diff_func=diff_func,
+                msg=snapshot_name or snapshot_file,
+                raise_cls=SnapshotChanged,
             )
 
 
@@ -225,7 +231,9 @@ def assert_snapshot(
             assert_equal(
                 got, expected,
                 fromfile=fromfile, tofile=tofile,
-                diff_func=diff_func
+                diff_func=diff_func,
+                msg=snapshot_name or snapshot_file,
+                raise_cls=SnapshotChanged,
             )
 
 
@@ -272,7 +280,9 @@ def assert_py_snapshot(
             assert_equal(
                 got_str, expected_str,
                 fromfile=fromfile, tofile=tofile,
-                diff_func=diff_func
+                diff_func=diff_func,
+                msg=snapshot_name or snapshot_file,
+                raise_cls=SnapshotChanged,
             )
 
 
@@ -379,5 +389,7 @@ def assert_binary_snapshot(
             assert_equal(
                 got, expected,
                 fromfile=fromfile, tofile=tofile,
-                diff_func=diff_func
+                diff_func=diff_func,
+                msg=snapshot_name or snapshot_file,
+                raise_cls=SnapshotChanged,
             )

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -58,7 +58,7 @@ class SnapshotTestCase(TestCase):
                 assert_snapshot(tmp_dir, 'snap', [{'foo': 42, 'bär': 23}], diff_func=pformat_ndiff)
             self.assertEqual(
                 str(exc_info.exception),
-                'Objects are not equal:\n'
+                'snap\n'
                 '  [\n'
                 '      {\n'
                 '-         "bär": 23,\n'
@@ -78,7 +78,7 @@ class SnapshotTestCase(TestCase):
                 assert_snapshot(tmp_dir, 'snap', [{'foo': 42, 'bär': 123}])
             self.assertEqual(
                 str(exc_info.exception),
-                'Objects are not equal:\n'
+                'snap\n'
                 '--- got\n'
                 '\n'
                 '+++ expected\n'
@@ -130,7 +130,7 @@ class SnapshotTestCase(TestCase):
                 assert_snapshot(tmp_dir, 'snap', [('foo', 42), 1, 1.5])
             self.assertEqual(
                 str(exc_info.exception),
-                'Objects are not equal:\n'
+                'snap\n'
                 '--- got\n\n'
                 '+++ expected\n\n'
                 '@@ -1 +1 @@\n\n'
@@ -161,7 +161,7 @@ class SnapshotTestCase(TestCase):
             assert written_text == 'this is:\nmultiline "text"\none\ntwo\nthree\nfour'
             self.assertEqual(
                 str(exc_info.exception),
-                'Text not equal:\n'
+                'text\n'
                 '- this is:\n'
                 '?        -\n'
                 '\n'
@@ -183,7 +183,7 @@ class SnapshotTestCase(TestCase):
                 )
             self.assertEqual(
                 str(exc_info.exception),
-                'Text not equal:\n'
+                'text\n'
                 '--- got\n'
                 '\n'
                 '+++ expected\n'
@@ -255,7 +255,7 @@ class SnapshotTestCase(TestCase):
                 assert_py_snapshot(tmp_dir, 'snap', example)
             self.assertEqual(
                 str(exc_info.exception),
-                "Objects are not equal:\n"
+                "snap\n"
                 "--- got\n"
                 "\n"
                 "+++ expected\n"
@@ -290,7 +290,7 @@ class SnapshotTestCase(TestCase):
                 assert_binary_snapshot(tmp_dir, 'binary-snap', got)
             self.assertEqual(
                 str(exc_info.exception),
-                'Objects are not equal:\n'
+                'binary-snap\n'
                 'expected: 2 Bytes, MD5 45aa1f1c9622b4a0f817b177a1b84f78\n'
                 'got: 4 Bytes, MD5 02df4e34a310564c0bb6245c432eb15e',
             )


### PR DESCRIPTION
state the snapshot name or file when a snapshot's content changes. this makes it easier to identify which snapshot was affected, especially with snapshots without explicit name.

also simplify the underlying assert functions by defining their fallback message in the argument definition.

this is what it looks like after the changes.
```
<traceback>
bx_py_utils.test_utils.snapshot.SnapshotChanged: /home/flbraun/Documents/myproject/test/test_classname_methodname_2.snapshot.json
--- got

+++ expected

<the diff>
```