### PR TITLE
Bugfix requests_mock_assertion if body is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ A simple mock for Boto3's S3 modules.
 
 #### bx_py_utils.test_utils.requests_mock_assertion
 
-* [`assert_json_requests_mock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L30-L45) - Check the requests mock history. In this case all requests must be JSON.
-* [`assert_json_requests_mock_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L48-L55) - Check requests mock history via snapshot. Accepts only JSON requests.
-* [`assert_requests_mock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L58-L78) - Check the requests mock history. Accept mixed "text" and "JSON".
-* [`assert_requests_mock_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L81-L86) - Check requests mock history via snapshot. Accept mixed "text" and "JSON".
+* [`assert_json_requests_mock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L29-L44) - Check the requests mock history. In this case all requests must be JSON.
+* [`assert_json_requests_mock_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L47-L54) - Check requests mock history via snapshot. Accepts only JSON requests.
+* [`assert_requests_mock()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L57-L77) - Check the requests mock history. Accept mixed "text" and "JSON".
+* [`assert_requests_mock_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/requests_mock_assertion.py#L80-L85) - Check requests mock history via snapshot. Accept mixed "text" and "JSON".
 
 #### bx_py_utils.test_utils.snapshot
 

--- a/bx_py_utils/test_utils/requests_mock_assertion.py
+++ b/bx_py_utils/test_utils/requests_mock_assertion.py
@@ -12,16 +12,15 @@ def build_requests_mock_history(mock, only_json=True):
         request_info = {
             'request': f'{request.method} {request.url}'
         }
-        try:
-            json_data = request.json()
-        except JSONDecodeError as err:
-            if only_json:
-                raise AssertionError(
-                    f'{request.method} {request.url} without valid JSON: {err} in:\n{err.doc!r}'
-                )
-            request_info['text'] = request.text
-        else:
-            request_info['json'] = json_data
+        if request.body:
+            try:
+                json_data = request.json()
+            except JSONDecodeError as err:
+                if only_json:
+                    raise AssertionError(f'{request.method} {request.url} without valid JSON: {err} in:\n{err.doc!r}')
+                request_info['text'] = request.text
+            else:
+                request_info['json'] = json_data
 
         history.append(request_info)
     return history

--- a/bx_py_utils_tests/tests/test_requests_mock_assertion.py
+++ b/bx_py_utils_tests/tests/test_requests_mock_assertion.py
@@ -120,3 +120,10 @@ class RequestsMockAssertionTestCase(TestCase):
             requests.post('http://test.tld', json={'foo': 'two'})
 
         assert_requests_mock_snapshot(mock=m)
+
+    def test_assert_json_requests_mock_with_none(self):
+        with requests_mock.mock() as m:
+            m.get('http://test.tld')
+            requests.get('http://test.tld')
+
+        assert_json_requests_mock(mock=m, data=[{'request': 'GET http://test.tld/'}])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bx_py_utils"
-version = "81"
+version = "82"
 description = "Various Python utility functions"
 homepage = "https://github.com/boxine/bx_py_utils/"
 authors = [


### PR DESCRIPTION
Don't try to deserialize when the request body is None.

Fix errors like:
```
Traceback (most recent call last):
File "bx_py_utils/bx_py_utils_tests/tests/test_requests_mock_assertion.py", line 129, in
test_assert_json_requests_mock_with_none
    assert_json_requests_mock(mock=m, data=[{'request': 'GET http://test.tld/'}])
File "bx_py_utils/bx_py_utils/test_utils/requests_mock_assertion.py", line 44, in
assert_json_requests_mock
    history = build_requests_mock_history(mock, only_json=True)
File "bx_py_utils/bx_py_utils/test_utils/requests_mock_assertion.py", line 16, in
build_requests_mock_history
    json_data = request.json()
  File "bx_py_utils/.venv/lib/python3.10/site-packages/requests_mock/request.py", line 155, in json
    return json.loads(self.text, **kwargs)
  File "/usr/lib/python3.10/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```