### PR TITLE
Make get_snapshot_file() public and more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,12 @@ A simple mock for Boto3's S3 modules.
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
 * [`SnapshotChanged()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L47-L48) - Assertion failed.
-* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L354-L395) - Assert binary data via snapshot file
-* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L289-L338) - Assert "html" string via snapshot file with validate and pretty format
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L240-L286) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L190-L237) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L142-L187) - Assert "text" string via snapshot file
+* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L363-L404) - Assert binary data via snapshot file
+* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L298-L347) - Assert "html" string via snapshot file with validate and pretty format
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L249-L295) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L199-L246) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L151-L196) - Assert "text" string via snapshot file
+* [`get_snapshot_file()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L121-L148) - Generate a file path use stack information to fill not provided path components.
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils_tests/tests/test_test_utils_snapshot.py
+++ b/bx_py_utils_tests/tests/test_test_utils_snapshot.py
@@ -18,12 +18,12 @@ from bx_py_utils.test_utils.filesystem_utils import FileWatcher
 from bx_py_utils.test_utils.snapshot import (
     _AUTO_SNAPSHOT_NAME_COUNTER,
     _get_caller_names,
-    _get_snapshot_file,
     assert_binary_snapshot,
     assert_html_snapshot,
     assert_py_snapshot,
     assert_snapshot,
     assert_text_snapshot,
+    get_snapshot_file,
 )
 
 
@@ -33,11 +33,11 @@ SELF_PATH = pathlib.Path(__file__).parent
 class SnapshotTestCase(TestCase):
     def test_get_snapshot_file(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            snapshot_file = _get_snapshot_file(root_dir=tmp_dir, snapshot_name='foo_bar', extension='.123')
+            snapshot_file = get_snapshot_file(root_dir=tmp_dir, snapshot_name='foo_bar', extension='.123')
             assert snapshot_file == pathlib.Path(tmp_dir) / 'foo_bar.snapshot.123'
             assert not snapshot_file.is_file()
 
-            snapshot_file = _get_snapshot_file(root_dir=tmp_dir, snapshot_name='foobar.snapshot', extension='.txt')
+            snapshot_file = get_snapshot_file(root_dir=tmp_dir, snapshot_name='foobar.snapshot', extension='.txt')
             assert snapshot_file == pathlib.Path(tmp_dir) / 'foobar.snapshot.txt'
             assert not snapshot_file.is_file()
 


### PR DESCRIPTION
To make the function usable in another way: Rename `_get_snapshot_file()` and make the hardcoded `.snapshot` changeable.