### PR TITLE
Follow RISON spec more closely

### DIFF
--- a/bx_py_utils/rison.py
+++ b/bx_py_utils/rison.py
@@ -14,13 +14,13 @@ def rison_dumps(obj):
         return '!n'
 
     if isinstance(obj, str):
-        if re.match(r'^[a-zA-Z_][-a-zA-Z0-9_]+$', obj):
+        if re.match(r'^[a-zA-Z_.][-a-zA-Z0-9_.]+$', obj):
             return obj  # no quoting necessary!
 
         return "'" + re.sub(r"([!'])", r'!\1', obj) + "'"
 
     if isinstance(obj, dict):
-        return '(' + ','.join(rison_dumps(k) + ':' + rison_dumps(v) for k, v in obj.items()) + ')'
+        return '(' + ','.join(rison_dumps(k) + ':' + rison_dumps(v) for k, v in sorted(obj.items())) + ')'
 
     if isinstance(obj, (list, tuple)):
         return '!(' + ','.join(rison_dumps(v) for v in obj) + ')'

--- a/bx_py_utils_tests/tests/test_rison.py
+++ b/bx_py_utils_tests/tests/test_rison.py
@@ -12,9 +12,14 @@ class RISONTest(TestCase):
         self.assertEqual(rison_dumps(''), "''")
         self.assertEqual(rison_dumps('ab'), 'ab')  # no quoting necessary!
         self.assertEqual(rison_dumps('now-2d'), 'now-2d')  # no quoting here either!
+        self.assertEqual(rison_dumps('.dot.'), '.dot.')  # even dots are fine
+        self.assertEqual(rison_dumps('1.1'), "'1.1'")  # need to be escaped when including a number
         self.assertEqual(rison_dumps('a b'), '\'a b\'')
         self.assertEqual(
             rison_dumps('a\'b\\c"d!e!!f'), "'a!'b\\c\"d!!e!!!!f'"
         )  # only ' and ! need to be escaped
         self.assertEqual(rison_dumps([]), '!()')
         self.assertEqual(rison_dumps({'x': 1, 'y z': [2, 3]}), "('x':1,'y z':!(2,3))")
+
+        # objects must be sorted
+        self.assertEqual(rison_dumps({'ab': '2nd', 'ac': 'third', 'aa': 'first'}), "(aa:first,ab:'2nd',ac:third)")


### PR DESCRIPTION
Allow dots, and sort keys, as demanded by the spec.
