### PR TITLE
Fix NoLogs

### DIFF
--- a/bx_py_utils/doc_write/README.md
+++ b/bx_py_utils/doc_write/README.md
@@ -66,11 +66,11 @@ Notes:
 
 ### Notes
 
+* The created created Markdown file is relative to `output_base_path` (defined in `pyproject.toml`)
+
+* Headlines will be sorted, so they appears ordered by the level.
+
 * All Doc-String without the `{prefix}` will be ignored.
 
 * The `{file-path}` must has the file extension `.md`
 Otherwise the DocString block will be ignored.
-
-* The created created Markdown file is relative to `output_base_path` (defined in `pyproject.toml`)
-
-* Headlines will be sorted, so they appears ordered by the level.

--- a/bx_py_utils/test_utils/log_utils.py
+++ b/bx_py_utils/test_utils/log_utils.py
@@ -22,7 +22,7 @@ class NoLogs:
     def __enter__(self):
         self.logger = logging.getLogger(self.logger_name)
         self.origin_handlers = self.logger.handlers
-        self.logger.handlers = []
+        self.logger.handlers = [logging.NullHandler()]
 
     def __exit__(self, exc_type, exc_value, tb):
         self.logger.handlers = self.origin_handlers

--- a/bx_py_utils_tests/tests/test_test_utils_log_utils.py
+++ b/bx_py_utils_tests/tests/test_test_utils_log_utils.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import logging
 from unittest import TestCase
 
@@ -25,3 +27,18 @@ class LogHandlerTestCase(TestCase):
             logger.info('After')
 
         self.assertEqual(logs.output, ['INFO:foobar:Before', 'INFO:foobar:After'])
+
+    def test_no_logs_no_stderr(self):
+        captured_logger = logging.getLogger('captured')
+
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            with NoLogs('captured'):
+                captured_logger.warning('This should not be written anywhere')
+        self.assertEqual(buf.getvalue(), '')
+
+    def test_no_logs_real(self):
+        # Just for reference, actually use this (should see something on stderr if the above capturing fails)
+        real_logger = logging.getLogger('real')
+        with NoLogs('real'):
+            real_logger.warning('This should not be visible in stderr')


### PR DESCRIPTION
NoLogs installed no handlers. But what happens if you don't install any handlers is that Python's logging framework automatically logs into a last-resort handler to stderr.
Fix this by installing a `NullHandler`, and add both a test capturing `sys.stderr` as well as just executing it so we can see it (in case the sys.stderr` capture fails).
