### PR TITLE
Bugfix run_doctests and optional excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Doc-Write, see: https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/do
 
 ### bx_py_utils.filename_matcher
 
-* [`filename_matcher()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/filename_matcher.py#L6-L22) - Enhance fnmatch that accept a list of patterns.
+* [`filename_matcher()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/filename_matcher.py#L6-L25) - Enhance fnmatch that accept a list of patterns.
 
 ### bx_py_utils.graphql_introspection
 

--- a/bx_py_utils/filename_matcher.py
+++ b/bx_py_utils/filename_matcher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import fnmatch
 
 
-def filename_matcher(*, patterns: list | tuple, file_path: str) -> bool:
+def filename_matcher(*, patterns: list | tuple | None, file_path: str) -> bool:
     """
     Enhance fnmatch that accept a list of patterns.
 
@@ -11,12 +11,15 @@ def filename_matcher(*, patterns: list | tuple, file_path: str) -> bool:
     False
     >>> filename_matcher(patterns=['*bar.py'], file_path='/foo/a-match-bar.py')
     True
+    >>> filename_matcher(patterns=None, file_path='/completely/no/matter.py')
+    False
     """
     assert isinstance(file_path, str), f'No string: {file_path=}'
 
-    for pattern in patterns:
-        assert isinstance(pattern, str), f'No string: {pattern=}'
-        if fnmatch.fnmatch(file_path, pattern):
-            return True  # File path match one of the pattern
+    if patterns:
+        for pattern in patterns:
+            assert isinstance(pattern, str), f'No string: {pattern=}'
+            if fnmatch.fnmatch(file_path, pattern):
+                return True  # File path match one of the pattern
 
     return False  # File path doesn't match any pattern

--- a/bx_py_utils_tests/tests/test_doctests.py
+++ b/bx_py_utils_tests/tests/test_doctests.py
@@ -13,3 +13,10 @@ class DocTests(BaseDocTests):
         self.assertGreaterEqual(results.passed, 80)
         self.assertEqual(results.skipped, 1)  # doctest_skip.py
         self.assertLessEqual(results.failed, 0)  # Failing test in doctest_skip.py skipped?
+
+    def test_doctests_without_excludes(self):
+        results = self.run_doctests(
+            modules=(bx_py_utils.test_utils,),
+            excludes=None,  # <<< should be optional!
+        )
+        self.assertIsInstance(results, DocTestResults)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bx_py_utils"
-version = "86"
+version = "87"
 description = "Various Python utility functions"
 homepage = "https://github.com/boxine/bx_py_utils/"
 authors = [


### PR DESCRIPTION
Sadly, the changes:
https://github.com/boxine/bx_py_utils/pull/180/commits/f82cb3b7313015332b44401c24d735a418385328#diff-5ddedf7646e83b7133361b398ae2746ea82dc77a3ba2ef39409fc2b503f04758 are not backward compatible, because `excludes=None` will crash in `filename_matcher()`. Fix this here.