### PR TITLE
Expand DocWrite with optional `delete_obsolete_files`

### DIFF
--- a/bx_py_utils/doc_write/README.md
+++ b/bx_py_utils/doc_write/README.md
@@ -47,7 +47,9 @@ Add a section `[tool.doc_write]` to your `pyproject.toml` to configure Doc-Write
 docstring_prefix = 'DocWrite:'
 output_base_path = './docs/'
 search_paths = ['./foo/', './bar/']
+delete_obsolete_files = false  # Delete obsolete files in output_base_path
 ```
+Warning: Turn `delete_obsolete_files` only on if output_base_path is excursively used by Doc-Write.
 
 ### Howto
 
@@ -67,6 +69,9 @@ Notes:
 ### Notes
 
 * The created created Markdown file is relative to `output_base_path` (defined in `pyproject.toml`)
+
+* If `delete_obsolete_files` is set to `true` in `pyproject.toml`,
+  then all `*.md` files in `output_base_path` that are not in `doc_paths` will be deleted.
 
 * Headlines will be sorted, so they appears ordered by the level.
 

--- a/bx_py_utils/doc_write/cfg.py
+++ b/bx_py_utils/doc_write/cfg.py
@@ -24,13 +24,16 @@ class DocuwriteConfig:
     docstring_prefix = 'DocWrite:'
     output_base_path = './docs/'
     search_paths = ['./foo/', './bar/']
+    delete_obsolete_files = false  # Delete obsolete files in output_base_path
     ```
+    Warning: Turn `delete_obsolete_files` only on if output_base_path is excursively used by Doc-Write.
     """
 
     base_path: Path
     search_paths: list[Path]
     output_base_path: Path
     docstring_prefix: str = 'DocWrite:'
+    delete_obsolete_files: bool = False  # Delete obsolete files in output_base_path
 
     def __post_init__(self):
         self.base_path = self.base_path.resolve(strict=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bx_py_utils"
-version = "90"
+version = "91"
 description = "Various Python utility functions"
 homepage = "https://github.com/boxine/bx_py_utils/"
 authors = [


### PR DESCRIPTION
If DocWrite strings will be remove in code base, so that a *.md file is completely obsolete, then this file will no be updated and not be removed, because it's just not "seen" and touched.

Add a `delete_obsolete_files` to config to remove all "unseen" *.md files from base path to cleanup.