### PR TITLE
PseudoS3Client: Implement copy_object

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Doc-Write, see: https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/do
 
 A simple mock for Boto3's S3 modules.
 
-* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L60-L246) - Simulates a boto3 S3 client object in tests
+* [`PseudoS3Client()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/mocks3.py#L61-L258) - Simulates a boto3 S3 client object in tests
 
 #### bx_py_utils.test_utils.redirect
 

--- a/bx_py_utils/test_utils/mocks3.py
+++ b/bx_py_utils/test_utils/mocks3.py
@@ -1,5 +1,6 @@
 """ A simple mock for Boto3's S3 modules. """
 
+import copy
 import io
 import pathlib
 
@@ -161,6 +162,17 @@ class PseudoS3Client:
     # noqa non-standard variable names from https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.delete_object
     def delete_object(self, Bucket, Key):
         del self.buckets[Bucket][Key]
+
+    # non-standard variable names for Boto3 compatibility
+    def copy_object(self, *, Bucket, CopySource, Key, ContentDisposition=None, MetadataDirective='COPY'):
+        bucket = self.buckets[Bucket]
+
+        src_bucket_name, _, src_key = CopySource.partition('/')
+        src_bucket = self.buckets[src_bucket_name]
+        if src_key not in src_bucket:
+            raise self.exceptions.NoSuchKey(src_key)
+
+        bucket[Key] = copy.deepcopy(src_bucket[src_key])
 
     def generate_presigned_url(self, *args, **kwargs):
         return self.origin_client.generate_presigned_url(*args, **kwargs)


### PR DESCRIPTION
Mock `copy_object` as described on https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/copy_object.html .
