### PR TITLE
NEW: DocWriteMacro: Add callables into DocWrite to complete the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Doc-Write, see: https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/do
 
 * [`human_timedelta()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/humanize/time.py#L14-L52) - Converts a time duration into a friendly text representation.
 
+### bx_py_utils.import_utils
+
+* [`import_string()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/import_utils.py#L18-L31) - Import a dotted module path and return the attribute/class designated by the last name in the path.
+
 ### bx_py_utils.iteration
 
 * [`chunk_iterable()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/iteration.py#L4-L21) - Returns a generator that yields slices of iterable of the given `chunk_size`.

--- a/bx_py_utils/doc_write/README.md
+++ b/bx_py_utils/doc_write/README.md
@@ -21,6 +21,42 @@ You can just search for the used prefix to find all code parts that contains Doc
 e.g.:
 * https://github.com/search?q=repo%3Aboxine%2Fbx_py_utils+%22DocWrite%3A%22&type=code
 
+## Macros
+
+It's possible to define callables in the DocString block by using the `DocWriteMacro:` prefix
+and the callable name as dotting path. e.g.:
+
+    DocWriteMacro: foo.bar.baz
+
+Example:
+
+```
+def add_context_attributes(macro_context: MacroContext):
+    """
+    Add MacroContext attributes to the documentation.
+    """
+    for field in dataclasses.fields(macro_context):
+        yield f' * {field.name}: {field.type.__name__}'
+
+```
+
+Macro functions must return a string or an iterable of strings.
+
+The recommendation is not to include the macro functions in the package.
+A good place could be next to the tests.
+e.g: The bx_py_utils own used doc write macros are stored in:
+
+* `bx_py_utils_tests/doc_write_macros.py`
+
+## Macros - context
+
+All macro functions will get a `MacroContext` dataclass instance as keyword argument with the following attributes:
+
+ * config: DocuwriteConfig
+ * path: str
+ * headline: str
+ * doc_string: str
+
 ## Usage
 
 To write your doc files, just call, e.g.:
@@ -52,11 +88,17 @@ Add a section `[tool.doc_write]` to your `pyproject.toml` to configure Doc-Write
 ```
 [tool.bx_py_utils.doc_write]
 docstring_prefix = 'DocWrite:'
+macro_prefix = 'DocWriteMacro:'
 output_base_path = './docs/'
 search_paths = ['./foo/', './bar/']
 delete_obsolete_files = false  # Delete obsolete files in output_base_path
 ```
-Warning: Turn `delete_obsolete_files` only on if output_base_path is excursively used by Doc-Write.
+Warning: Turn `delete_obsolete_files` only on if output_base_path is exclusively used by Doc-Write.
+
+Defaults are:
+ * `docstring_prefix`: `'DocWrite:'`
+ * `macro_prefix`: `'DocWriteMacro:'`
+ * `delete_obsolete_files`: `False`
 
 ### Howto
 

--- a/bx_py_utils/doc_write/api.py
+++ b/bx_py_utils/doc_write/api.py
@@ -24,22 +24,15 @@
 
 from __future__ import annotations
 
-import dataclasses
 import logging
 from pathlib import Path
 
-from bx_py_utils.doc_write.cfg import DocuwriteConfig, get_docu_write_cfg
+from bx_py_utils.doc_write.cfg import get_docu_write_cfg
+from bx_py_utils.doc_write.data_structures import DocuwriteConfig, GeneratedInfo
 from bx_py_utils.doc_write.docstrings import collect_docstrings
 
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass
-class GeneratedInfo:
-    update_count: int
-    remove_count: int
-    paths: list[Path]
 
 
 def _needs_write(out_path: Path, content: str) -> bool:

--- a/bx_py_utils/doc_write/cfg.py
+++ b/bx_py_utils/doc_write/cfg.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import dataclasses
 import logging
 from pathlib import Path
 
+from bx_py_utils.doc_write.data_structures import DocuwriteConfig
 from bx_py_utils.pyproject_toml import get_pyproject_config
 
 
@@ -14,34 +14,6 @@ DEFAULT_CFG = {
     'search_paths': ['.'],  # List of search paths for source files
     'output_base_path': './docs/',  # Base path for *.md output files
 }
-
-
-@dataclasses.dataclass
-class DocuwriteConfig:
-    """DocWrite: bx_py_utils/doc_write/README.md ## pyproject.toml settings [tool.doc_write] example
-    ```
-    [tool.bx_py_utils.doc_write]
-    docstring_prefix = 'DocWrite:'
-    output_base_path = './docs/'
-    search_paths = ['./foo/', './bar/']
-    delete_obsolete_files = false  # Delete obsolete files in output_base_path
-    ```
-    Warning: Turn `delete_obsolete_files` only on if output_base_path is excursively used by Doc-Write.
-    """
-
-    base_path: Path
-    search_paths: list[Path]
-    output_base_path: Path
-    docstring_prefix: str = 'DocWrite:'
-    delete_obsolete_files: bool = False  # Delete obsolete files in output_base_path
-
-    def __post_init__(self):
-        self.base_path = self.base_path.resolve(strict=True)
-
-        self.search_paths = [Path(self.base_path / path).resolve(strict=False) for path in self.search_paths]
-        self.search_paths = [path for path in self.search_paths if path.is_dir()]
-
-        self.output_base_path = Path(self.base_path / self.output_base_path).resolve(strict=False)
 
 
 def get_docu_write_cfg(base_path: Path | None = None) -> DocuwriteConfig:

--- a/bx_py_utils/doc_write/data_structures.py
+++ b/bx_py_utils/doc_write/data_structures.py
@@ -1,0 +1,57 @@
+import dataclasses
+from pathlib import Path
+
+
+@dataclasses.dataclass
+class GeneratedInfo:
+    update_count: int
+    remove_count: int
+    paths: list[Path]
+
+
+@dataclasses.dataclass
+class DocuwriteConfig:
+    """DocWrite: bx_py_utils/doc_write/README.md ## pyproject.toml settings [tool.doc_write] example
+    ```
+    [tool.bx_py_utils.doc_write]
+    docstring_prefix = 'DocWrite:'
+    macro_prefix = 'DocWriteMacro:'
+    output_base_path = './docs/'
+    search_paths = ['./foo/', './bar/']
+    delete_obsolete_files = false  # Delete obsolete files in output_base_path
+    ```
+    Warning: Turn `delete_obsolete_files` only on if output_base_path is exclusively used by Doc-Write.
+
+    Defaults are:
+    DocWriteMacro: bx_py_utils_tests.doc_write_macros.config_defaults
+    """
+
+    base_path: Path
+    search_paths: list[Path]
+    output_base_path: Path
+    docstring_prefix: str = 'DocWrite:'
+    macro_prefix: str = 'DocWriteMacro:'
+    delete_obsolete_files: bool = False  # Delete obsolete files in output_base_path
+
+    def __post_init__(self):
+        self.base_path = self.base_path.resolve(strict=True)
+
+        self.search_paths = [Path(self.base_path / path).resolve(strict=False) for path in self.search_paths]
+        self.search_paths = [path for path in self.search_paths if path.is_dir()]
+
+        self.output_base_path = Path(self.base_path / self.output_base_path).resolve(strict=False)
+
+
+@dataclasses.dataclass
+class MacroContext:
+    """
+    DocWrite: bx_py_utils/doc_write/README.md ## Macros - context
+    All macro functions will get a `MacroContext` dataclass instance as keyword argument with the following attributes:
+
+    DocWriteMacro: bx_py_utils_tests.doc_write_macros.add_context_attributes
+    """
+
+    config: DocuwriteConfig
+    path: str
+    headline: str
+    doc_string: str

--- a/bx_py_utils/doc_write/macro.py
+++ b/bx_py_utils/doc_write/macro.py
@@ -1,0 +1,66 @@
+import logging
+import re
+from collections.abc import Iterable
+
+from bx_py_utils.doc_write.data_structures import MacroContext
+from bx_py_utils.import_utils import import_string
+
+
+logger = logging.getLogger(__name__)
+
+
+class CallMacro:
+    def __init__(self, macro_context: MacroContext):
+        self.macro_context = macro_context
+
+    def __call__(self, match):
+        dotted_path = match.group(1)
+        logger.info('Call macro function %r', dotted_path)
+
+        macro_func = import_string(dotted_path)
+
+        try:
+            result = macro_func(macro_context=self.macro_context)
+        except Exception as err:
+            raise Exception(f'Call macro {dotted_path!r} error: {err}') from err
+
+        """
+        DocWrite: bx_py_utils/doc_write/README.md ## Macros
+        Macro functions must return a string or an iterable of strings.
+        """
+
+        if isinstance(result, str):
+            return result
+        if isinstance(result, Iterable):
+            try:
+                return '\n'.join(part for part in result)
+            except TypeError as err:
+                raise TypeError(f'Error consuming macro {dotted_path!r}: {err}') from err
+        else:
+            raise TypeError(f'Macro {dotted_path!r} must return str or Iterable[str], not {type(result).__name__}')
+
+
+def process_macros(*, macro_context: MacroContext):
+    """
+    DocWrite: bx_py_utils/doc_write/README.md ## Macros
+    It's possible to define callables in the DocString block by using the `DocWriteMacro:` prefix
+    and the callable name as dotting path. e.g.:
+
+        DocWriteMacro: foo.bar.baz
+
+    Example:
+
+    ```
+    DocWriteMacro: bx_py_utils_tests.doc_write_macros.macro_example_sources
+    ```
+    """
+    config = macro_context.config
+    macro_prefix = config.macro_prefix
+    call_macro = CallMacro(macro_context)
+    doc_string = re.sub(
+        rf'^{macro_prefix}\s*([a-zA-Z0-9_.]+)\s*$',
+        call_macro,
+        macro_context.doc_string,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    return doc_string

--- a/bx_py_utils/import_utils.py
+++ b/bx_py_utils/import_utils.py
@@ -1,0 +1,31 @@
+# Based on Django's module_loading.py
+
+import sys
+from importlib import import_module
+
+
+def cached_import(module_path, class_name):
+    # Check whether module is loaded and fully initialized.
+    if not (
+        (module := sys.modules.get(module_path))
+        and (spec := getattr(module, "__spec__", None))
+        and getattr(spec, "_initializing", False) is False
+    ):
+        module = import_module(module_path)
+    return getattr(module, class_name)
+
+
+def import_string(dotted_path):
+    """
+    Import a dotted module path and return the attribute/class designated by the last name in the path.
+    Raise ImportError if the import failed.
+    """
+    try:
+        module_path, class_name = dotted_path.rsplit(".", 1)
+    except ValueError as err:
+        raise ImportError(f"{dotted_path} doesn't look like a module path") from err
+
+    try:
+        return cached_import(module_path, class_name)
+    except AttributeError as err:
+        raise ImportError(f'Module "{module_path}" does not define a "{class_name}" attribute/class') from err

--- a/bx_py_utils_tests/doc_write_macros.py
+++ b/bx_py_utils_tests/doc_write_macros.py
@@ -1,0 +1,41 @@
+"""
+    DocWrite: bx_py_utils/doc_write/README.md ## Macros
+
+    The recommendation is not to include the macro functions in the package.
+    A good place could be next to the tests.
+    e.g: The bx_py_utils own used doc write macros are stored in:
+
+    * `bx_py_utils_tests/doc_write_macros.py`
+"""
+
+import dataclasses
+import inspect
+
+from bx_py_utils.doc_write.data_structures import MacroContext
+
+
+def add_context_attributes(macro_context: MacroContext):
+    """
+    Add MacroContext attributes to the documentation.
+    """
+    for field in dataclasses.fields(macro_context):
+        yield f' * {field.name}: {field.type.__name__}'
+
+
+def macro_example_sources(macro_context: MacroContext):
+    """
+    Adds `add_context_attributes` source code as a example to the documentation.
+    """
+    return inspect.getsource(add_context_attributes)
+
+
+def config_defaults(macro_context: MacroContext):
+    """
+    Add the default values of the `DocuwriteConfig` dataclass to the documentation.
+    """
+    for field in dataclasses.fields(macro_context.config):
+        if field.default is dataclasses.MISSING:
+            continue
+
+        value = getattr(macro_context.config, field.name)
+        yield f' * `{field.name}`: `{value!r}`'

--- a/bx_py_utils_tests/tests/test_doc_write_api.py
+++ b/bx_py_utils_tests/tests/test_doc_write_api.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from unittest import TestCase
 
 from bx_py_utils.doc_write.api import GeneratedInfo, generate
-from bx_py_utils.doc_write.cfg import DocuwriteConfig, get_docu_write_cfg
+from bx_py_utils.doc_write.cfg import get_docu_write_cfg
+from bx_py_utils.doc_write.data_structures import DocuwriteConfig
 from bx_py_utils.path import assert_is_file
 
 

--- a/bx_py_utils_tests/tests/test_doc_write_cfg.py
+++ b/bx_py_utils_tests/tests/test_doc_write_cfg.py
@@ -3,7 +3,8 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
-from bx_py_utils.doc_write.cfg import DocuwriteConfig, get_docu_write_cfg
+from bx_py_utils.doc_write.cfg import get_docu_write_cfg
+from bx_py_utils.doc_write.data_structures import DocuwriteConfig
 
 
 class DocuWriteCfgTestCase(TestCase):


### PR DESCRIPTION
Sometimes it's helpful to add dynamic content to the documentation. This can be done with macros.
Macros are defined in the DocString block by using the `DocWriteMacro:` prefix
and the callable name as dotting path. e.g.:

    DocWriteMacro: foo.bar.baz