### PR TITLE
Compatibility with Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.11", "3.10"]
+        python-version: ["3.13", "3.12", "3.11", "3.10"]
     steps:
     - name: Checkout
       run: |

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ Doc-Write, see: https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/do
 
 ### bx_py_utils.stack_info
 
-* [`FrameNotFound()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L8-L13) - Base class for lookup errors.
-* [`last_frame_outside_path()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L16-L44) - Returns the stack frame that is the direct successor of given "file_path".
+* [`FrameNotFound()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L7-L12) - Base class for lookup errors.
+* [`last_frame_outside_path()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/stack_info.py#L15-L43) - Returns the stack frame that is the direct successor of given "file_path".
 
 ### bx_py_utils.string_utils
 
@@ -220,13 +220,13 @@ A simple mock for Boto3's S3 modules.
 
 Assert complex output via auto updated snapshot files with nice diff error messages.
 
-* [`SnapshotChanged()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L50-L51) - Assertion failed.
-* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L366-L407) - Assert binary data via snapshot file
-* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L301-L350) - Assert "html" string via snapshot file with validate and pretty format
-* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L252-L298) - Assert complex python objects vio PrettyPrinter() snapshot file.
-* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L202-L249) - Assert given data serialized to JSON snapshot file.
-* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L154-L199) - Assert "text" string via snapshot file
-* [`get_snapshot_file()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L124-L151) - Generate a file path use stack information to fill not provided path components.
+* [`SnapshotChanged()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L51-L52) - Assertion failed.
+* [`assert_binary_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L367-L408) - Assert binary data via snapshot file
+* [`assert_html_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L302-L351) - Assert "html" string via snapshot file with validate and pretty format
+* [`assert_py_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L253-L299) - Assert complex python objects vio PrettyPrinter() snapshot file.
+* [`assert_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L203-L250) - Assert given data serialized to JSON snapshot file.
+* [`assert_text_snapshot()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L155-L200) - Assert "text" string via snapshot file
+* [`get_snapshot_file()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/test_utils/snapshot.py#L125-L152) - Generate a file path use stack information to fill not provided path components.
 
 #### bx_py_utils.test_utils.time
 

--- a/bx_py_utils/environ.py
+++ b/bx_py_utils/environ.py
@@ -18,7 +18,7 @@ def cgroup_memory_usage(unit='B', cgroup_mem_file='/sys/fs/cgroup/memory/memory.
     With conventional tools (e.g. psutil) this is not possible, because they often rely on
     stats reported by /proc, but that one reports metrics from the host system.
     """
-    with open(cgroup_mem_file, 'r') as infile:
+    with open(cgroup_mem_file) as infile:
         usage_bytes = infile.readline()
     usage_bytes = int(usage_bytes)
 

--- a/bx_py_utils/stack_info.py
+++ b/bx_py_utils/stack_info.py
@@ -1,6 +1,5 @@
 import inspect
 from pathlib import Path
-from typing import Union
 
 from bx_py_utils.path import assert_is_file
 
@@ -13,7 +12,7 @@ class FrameNotFound(LookupError):
         return f'Frame outside "{self.file_path}" not found!'
 
 
-def last_frame_outside_path(file_path: Union[Path, str]):
+def last_frame_outside_path(file_path: Path | str):
     """
     Returns the stack frame that is the direct successor of given "file_path".
     The use case may be to find caller information.

--- a/bx_py_utils/test_utils/assertion.py
+++ b/bx_py_utils/test_utils/assertion.py
@@ -1,6 +1,6 @@
 import difflib
 import pprint
-from typing import Any, Type
+from typing import Any
 
 from bx_py_utils.humanize.pformat import pformat
 
@@ -68,7 +68,7 @@ def assert_equal(
     fromfile: str = 'got',
     tofile: str = 'expected',
     diff_func=pformat_unified_diff,
-    raise_cls: Type[Exception] = AssertionError,
+    raise_cls: type[Exception] = AssertionError,
 ):
     """
     Check if the two objects are the same. Display a nice diff, using `pformat()`
@@ -84,7 +84,7 @@ def assert_text_equal(
     fromfile: str = 'got',
     tofile: str = 'expected',
     diff_func=text_unified_diff,
-    raise_cls: Type[Exception] = AssertionError,
+    raise_cls: type[Exception] = AssertionError,
 ):
     """
     Check if the two text strings are the same. Display an error message with a diff.

--- a/bx_py_utils/test_utils/snapshot.py
+++ b/bx_py_utils/test_utils/snapshot.py
@@ -13,7 +13,8 @@ import pathlib
 import pprint
 import re
 from collections import Counter
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from bx_py_utils.html_utils import get_html_elements, pretty_format_html, validate_html
 

--- a/bx_py_utils_tests/tests/test_environ.py
+++ b/bx_py_utils_tests/tests/test_environ.py
@@ -18,7 +18,7 @@ class DockerTestCase(TestCase):
         for unit, value in expectations.items():
             with patch('bx_py_utils.environ.open', mock_open(read_data='524288000')) as m:
                 usage = cgroup_memory_usage(unit=unit)
-            m.assert_called_once_with('/sys/fs/cgroup/memory/memory.usage_in_bytes', 'r')
+            m.assert_called_once_with('/sys/fs/cgroup/memory/memory.usage_in_bytes')
             assert usage == value
 
 

--- a/bx_py_utils_tests/tests/test_utils/test_mocks3.py
+++ b/bx_py_utils_tests/tests/test_utils/test_mocks3.py
@@ -120,7 +120,7 @@ class S3MockTest(TestCase):
 
     def test_list_buckets(self):
         s3 = PseudoS3Client(init_buckets=('buck', 'foo-bar-123'))
-        bucket_names = set(b['Name'] for b in s3.list_buckets()['Buckets'])
+        bucket_names = {b['Name'] for b in s3.list_buckets()['Buckets']}
         self.assertEqual(bucket_names, {'buck', 'foo-bar-123'})
         self.assertEqual(s3.head_bucket('buck')['ResponseMetadata']['HTTPStatusCode'], 200)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,10 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
     "Intended Audience :: Developers",
 ]
@@ -125,7 +126,7 @@ exclude_lines = [
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py{312,311,310}
+envlist = py{313,312,311,310}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Also run `pyupgrade --py310-plus` against the codebase as that is our minimum supported version.