### PR TITLE
remove remainders of pipenv

### DIFF
--- a/bx_py_utils_tests/publish.py
+++ b/bx_py_utils_tests/publish.py
@@ -20,8 +20,6 @@ def publish():
     PACKAGE_ROOT = Path(__file__).parent.parent
     assert_is_file(PACKAGE_ROOT / 'pyproject.toml')
 
-    subprocess.check_call(['pipenv', 'check'])
-
     subprocess.check_call(['make', 'test'])  # don't publish if tests fail
     subprocess.check_call(['make', 'fix-code-style'])  # don't publish if code style wrong
 


### PR DESCRIPTION
in 50f34991 pipenv was removed from the project in favor of uv, but `pipenv check` is still used in the publishing script. it effectively does nothing because there is no Pipfile containing dependencies that could be checked.

unfortunately uv doesn't have equivalent functionality (yet), but there are other ways to ensure safe/up-to-date dependencies (e.g. using dependabot).