### PR TITLE
Bugfix "make publish"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dev = [
     'openpyxl',  # https://foss.heptapod.net/openpyxl/openpyxl
     'parameterized',  # https://github.com/wolever/parameterized
 
+    'build', # https://github.com/pypa/build
+
     "manageprojects",  # https://github.com/jedie/manageprojects
     "urllib3", # for bx_py_utils.test_utils.deny_requests.deny_any_real_request() in tests
     "uv",  # https://github.com/astral-sh/uv
@@ -58,11 +60,6 @@ dev = [
     # https://github.com/pycqa/isort
     # https://github.com/pygments/pygments
     'darker[flynt, isort, color]',
-
-    # Work-a-round for: https://github.com/jazzband/pip-tools/issues/1866
-    # see also: https://github.com/jazzband/pip-tools/issues/994#issuecomment-1321226661
-    # backports.tarfile is needed for python <3.12
-    'backports.tarfile', # via jaraco-context -> keyring -> twine
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -176,16 +176,32 @@ wheels = [
 ]
 
 [[package]]
+name = "build"
+version = "1.2.2.post1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.10.2'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950 },
+]
+
+[[package]]
 name = "bx-py-utils"
-version = "107"
+version = "108"
 source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
     { name = "autopep8" },
-    { name = "backports-tarfile" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
+    { name = "build" },
     { name = "codespell" },
     { name = "coverage" },
     { name = "darker", extra = ["color", "flynt", "isort"] },
@@ -217,9 +233,9 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "autopep8" },
-    { name = "backports-tarfile" },
     { name = "beautifulsoup4" },
     { name = "boto3" },
+    { name = "build" },
     { name = "codespell" },
     { name = "coverage" },
     { name = "darker", extras = ["flynt", "isort", "color"] },
@@ -1473,6 +1489,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bb/19/441e0624a8afedd15bbcce96df1b80479dd0ff0d965f5ce8fde4f2f6ffad/pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496", size = 22340 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/f4/3c4ddfcc0c19c217c6de513842d286de8021af2f2ab79bbb86c00342d778/pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228", size = 13100 },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
 ]
 
 [[package]]


### PR DESCRIPTION
Current call of "make publish" ran into: "No module named build"

Just add the needed "build" package. Think it was missed on pip-tools -> uv migration. Maybe we can also build via uv in the future.

Also remove the pip-tools work-a-round for https://github.com/jazzband/pip-tools/issues/1866 It's obsolete with uv.