### PR TITLE
Bugfix tests: Don't call DenyAnyRealRequestContextManager a second time

### DIFF
--- a/bx_py_utils_tests/tests/test_utils/test_deny_requests.py
+++ b/bx_py_utils_tests/tests/test_utils/test_deny_requests.py
@@ -5,20 +5,22 @@ from unittest.mock import patch
 
 import requests
 
-from bx_py_utils.test_utils.deny_requests import DenyAnyRealRequestContextManager, DenyCallError, deny_any_real_request
+from bx_py_utils.test_utils.deny_requests import DenyCallError, deny_any_real_request
 
 
 class DenyAnyRealRequestTestCase(TestCase):
     def test_happy_path(self):
+
+        # We must not activate DenyAnyRealRequestContextManager here, because it's always used in tests.
+        # Activated in bx_py_utils_tests.tests.pre_configure_tests()
+
         with self.assertRaises(DenyCallError) as cm:
-            with DenyAnyRealRequestContextManager():
-                urllib.request.urlopen('http://www.python.org/')
+            urllib.request.urlopen('http://www.python.org/')
         self.assertIn('Deny socket create_connection() call', cm.exception.args[0])
 
         # requests used urllib3 ;)
         with self.assertRaises(DenyCallError) as cm:
-            with DenyAnyRealRequestContextManager():
-                requests.get('http://www.python.org/')
+            requests.get('http://www.python.org/')
         self.assertIn('Deny urllib3 create_connection() call', cm.exception.args[0])
 
     def test_deny_any_real_request(self):


### PR DESCRIPTION
`DenyAnyRealRequestContextManager` is always activated in tests via `bx_py_utils_tests.tests.pre_configure_tests()`

In newer Python 3.12 versions a second activation will result in: `RuntimeError: Patch is already started`

See:
https://github.com/boxine/bx_py_utils/actions/runs/15489145051/job/43610492101?pr=227#step:5:159

Just remove the second activation and leave a comment there...