### PR TITLE
Bugfix compare functions edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please take a look into the sources and tests for deeper informations.
 
 ### bx_py_utils.dict_utils
 
-* [`compare_dict_values()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L98-L128) - Compare two dictionaries if values of the same keys are present and equal.
+* [`compare_dict_values()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L98-L145) - Compare two dictionaries if values of the same keys are present and equal.
 * [`dict_get()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L9-L30) - nested dict `get()`
 * [`dict_list2markdown()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L48-L78) - Convert a list of dictionaries into a markdown table.
 * [`pluck()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/dict_utils.py#L33-L45) - Extract values from a dict, if they are present

--- a/bx_py_utils/dict_utils.py
+++ b/bx_py_utils/dict_utils.py
@@ -102,6 +102,24 @@ def compare_dict_values(dict1: dict, dict2: dict) -> DictCompareResult:
     >>> compare_dict_values({'a': 1}, {'a': 1, 'c': 2})
     DictCompareResult(correct_keys={'a': 1}, wrong_keys={}, skipped_keys={'c': {'expected': 2, 'current': None}})
 
+    >>> compare_dict_values({'a': 0}, {'a': 1})
+    DictCompareResult(correct_keys={}, wrong_keys={'a': {'expected': 1, 'current': 0}}, skipped_keys={})
+
+    The key must be present in both:
+    >>> compare_dict_values({'a': None}, {})
+    DictCompareResult(correct_keys={}, wrong_keys={}, skipped_keys={'a': {'expected': None, 'current': None}})
+    >>> compare_dict_values({}, {'a': 0})
+    DictCompareResult(correct_keys={}, wrong_keys={}, skipped_keys={'a': {'expected': 0, 'current': None}})
+
+    Comapre 0 or False or None on both sides is successful:
+    >>> compare_dict_values({'a': 0}, {'a': 0})
+    DictCompareResult(correct_keys={'a': 0}, wrong_keys={}, skipped_keys={})
+    >>> compare_dict_values({'a': False}, {'a': False})
+    DictCompareResult(correct_keys={'a': False}, wrong_keys={}, skipped_keys={})
+    >>> compare_dict_values({'a': None}, {'a': None})
+    DictCompareResult(correct_keys={'a': None}, wrong_keys={}, skipped_keys={})
+
+    We also check the types, e.g.: 1 is not equal to True:
     >>> compare_dict_values({'a': 1}, {'a': True})
     DictCompareResult(correct_keys={}, wrong_keys={'a': {'expected': True, 'current': 1}}, skipped_keys={})
     """
@@ -112,13 +130,12 @@ def compare_dict_values(dict1: dict, dict2: dict) -> DictCompareResult:
     for key in key_union:
         expected_value = dict2.get(key)
         current_value = dict1.get(key)
-        if expected_value and current_value:
-            if expected_value is current_value:
-                correct_keys[key] = expected_value
-            else:
-                wrong_keys[key] = {'expected': expected_value, 'current': current_value}
-        else:
+        if key not in dict1 or key not in dict2:
             skipped_keys[key] = {'expected': expected_value, 'current': current_value}
+        elif type(expected_value) == type(current_value) and expected_value == current_value:  # noqa: E721
+            correct_keys[key] = expected_value
+        else:
+            wrong_keys[key] = {'expected': expected_value, 'current': current_value}
 
     result = DictCompareResult(
         correct_keys=correct_keys,


### PR DESCRIPTION
Sometimes doing it right is hard.

Using `is` doesn't work if we have two string with the same values but different `id()`. Python aggressively reuses immutable objects like strings to optimize memory usage.

Nevertheless, I have seen in practice that this is exactly what happens: Same value but different objects.

It's hard to test this. All of this doesn't create different objects, e.g.:

```
value1 = 'foobar'

# All doesn't work:
value2 = 'foo' + 'bar'
value2 = str(value1)
value2 = value1[:]
value2 = copy.deepcopy(value1)
value2 = "".join([value1])
```

What works for me is: `bytearray(value1, 'utf-8').decode('utf-8')` ... Using this in our tests.