### PR TITLE
Bugfix publish: Remove "make fix-code-style"

### DIFF
--- a/bx_py_utils_tests/publish.py
+++ b/bx_py_utils_tests/publish.py
@@ -21,7 +21,6 @@ def publish():
     assert_is_file(PACKAGE_ROOT / 'pyproject.toml')
 
     subprocess.check_call(['make', 'test'])  # don't publish if tests fail
-    subprocess.check_call(['make', 'fix-code-style'])  # don't publish if code style wrong
 
     publish_package(module=bx_py_utils, package_path=PACKAGE_ROOT)
 


### PR DESCRIPTION
We replaced this make target with "make lint" in https://github.com/boxine/bx_py_utils/pull/234/

Anyway: Remove it from "publish", because run the tests will check the code style with: `ProjectSetupTestCase.test_code_style()`