### PR TITLE
Add strip_html_tags and html2text

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,13 @@ Doc-Write, see: https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/do
 
 ### bx_py_utils.html_utils
 
-* [`ElementsNotFoundError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L44-L48) - Happens if requested HTML elements cannot be found
-* [`InvalidHtml()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L18-L41) - XMLSyntaxError with better error messages: used in validate_html()
-* [`get_html_elements()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L95-L106) - Returns the selected HTML elements as string
-* [`pretty_format_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L87-L92) - Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
-* [`validate_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L51-L73) - Validate a HTML document via XMLParser (Needs 'lxml' package)
+* [`ElementsNotFoundError()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L49-L53) - Happens if requested HTML elements cannot be found
+* [`InvalidHtml()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L23-L46) - XMLSyntaxError with better error messages: used in validate_html()
+* [`get_html_elements()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L100-L112) - Returns the selected HTML elements as string
+* [`html2text()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L186-L201) - Convert HTML to plain text, preserving paragraph breaks as double newlines.
+* [`pretty_format_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L92-L97) - Pretty format given HTML document via BeautifulSoup (Needs 'beautifulsoup4' package)
+* [`strip_html_tags()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L163-L183) - Remove HTML tags from a string using stdlib HTMLParser.
+* [`validate_html()`](https://github.com/boxine/bx_py_utils/blob/master/bx_py_utils/html_utils.py#L56-L78) - Validate a HTML document via XMLParser (Needs 'lxml' package)
 
 #### bx_py_utils.humanize.pformat
 

--- a/bx_py_utils/html_utils.py
+++ b/bx_py_utils/html_utils.py
@@ -1,3 +1,8 @@
+import html as _html
+import re
+from html.parser import HTMLParser
+
+from bx_py_utils.string_utils import ensure_lf
 from bx_py_utils.text_tools import cutout
 
 
@@ -101,6 +106,96 @@ def get_html_elements(data, query_selector, parser='html.parser', **bs_kwargs):
 
     if not selected_elements:
         raise ElementsNotFoundError(
-            f'The query selector {query_selector} did not match any element in the HTML document')
+            f'The query selector {query_selector} did not match any element in the HTML document'
+        )
 
     return ''.join(str(tag) for tag in selected_elements)
+
+
+class _HTMLStripper(HTMLParser):
+    def __init__(self, keep_paragraphs):
+        self.keep_paragraphs = keep_paragraphs
+        super().__init__(convert_charrefs=False)
+        self.fed = []
+
+    def handle_data(self, d):
+        d = re.sub(r'[\t\r\f\v]', ' ', d)
+        self.fed.append(d)
+
+    def handle_entityref(self, name):
+        self.fed.append(_html.unescape(f'&{name};'))
+
+    def handle_charref(self, name):
+        self.fed.append(_html.unescape(f'&#{name};'))
+
+    def handle_starttag(self, tag, attributes):
+        if tag == 'li':
+            self.fed.append('· ')
+        super().handle_starttag(tag, attributes)
+
+    def handle_endtag(self, tag):
+        if self.keep_paragraphs and tag == 'p':
+            self.fed.append('\n')
+        else:
+            self.fed.append(' ')
+
+    def get_data(self):
+        data = ''.join(self.fed)
+        data = re.sub(r'[ ]{2,}', ' ', data)
+        if self.keep_paragraphs:
+            data = '\n'.join(line.strip() for line in data.splitlines())
+        else:
+            data = ' '.join(line.strip() for line in data.splitlines() if line.strip())
+            data = re.sub(r'\s{2,}', ' ', data)
+
+        data = re.sub(r'(\n{2})\n+', r'\1', data)
+        data = data.strip()
+        return data
+
+
+def _strip_html_once(value: str, *, keep_paragraphs: bool) -> str:
+    s = _HTMLStripper(keep_paragraphs)
+    s.feed(value)
+    s.close()
+    return s.get_data()
+
+
+def strip_html_tags(value: str, *, keep_paragraphs: bool = False) -> str:
+    """
+    Remove HTML tags from a string using stdlib HTMLParser.
+
+    Runs the parser in a loop until no more tags are detected, because
+    HTMLParser can miss tags on the first pass (e.g. inside <style> blocks).
+
+    >>> strip_html_tags('<p>Hello <b>World</b></p>')
+    'Hello World'
+    >>> strip_html_tags('<p>First</p><p>Second</p>', keep_paragraphs=True)
+    'First\\nSecond'
+    """
+    assert isinstance(value, str), f'Expected a string, got {type(value).__name__}'
+    value = _strip_html_once(value, keep_paragraphs=keep_paragraphs)
+    while '<' in value and '>' in value:
+        new_value = _strip_html_once(value, keep_paragraphs=keep_paragraphs)
+        if new_value == value:
+            # no progress — remaining '<' / '>' are not HTML tags -> exit loop
+            break
+        value = new_value
+    return value
+
+
+def html2text(value: str) -> str:
+    """
+    Convert HTML to plain text, preserving paragraph breaks as double newlines.
+
+    >>> html2text('<p>First</p>\\n\\n<p>Second</p>')
+    'First\\n\\nSecond'
+    """
+    assert isinstance(value, str), f'Expected a string, got {type(value).__name__}'
+    text = ensure_lf(value)
+    text = strip_html_tags(text, keep_paragraphs=True)  # preserve paragraphs as newlines
+    parts = re.split(r'\n{2,}', text)
+    parts = (
+        strip_html_tags(part, keep_paragraphs=False)  # remove any remaining tags and extra whitespace from each part
+        for part in parts
+    )
+    return '\n\n'.join(parts)

--- a/bx_py_utils_tests/tests/test_html_utils.py
+++ b/bx_py_utils_tests/tests/test_html_utils.py
@@ -2,8 +2,17 @@ import inspect
 from unittest import TestCase
 from unittest.mock import patch
 
+import typeguard
+
 from bx_py_utils import html_utils
-from bx_py_utils.html_utils import InvalidHtml, pretty_format_html, validate_html
+from bx_py_utils.html_utils import (
+    InvalidHtml,
+    _strip_html_once,
+    html2text,
+    pretty_format_html,
+    strip_html_tags,
+    validate_html,
+)
 
 
 class HtmlUtilsTestCase(TestCase):
@@ -91,3 +100,83 @@ class HtmlUtilsTestCase(TestCase):
             cm.exception.args,
             ('This feature needs "beautifulsoup4", please add it to you requirements',),
         )
+
+
+class StripHtmlTagsTests(TestCase):
+    def test_basics(self):
+        self.assertEqual(strip_html_tags('<foo>bar</foo>'), 'bar')
+        self.assertEqual(strip_html_tags('foo&nbsp;&amp;&nbsp;bar'), 'foo\xa0&\xa0bar')
+        self.assertEqual(strip_html_tags('foo&#169;bar'), 'foo\xa9bar')
+        self.assertEqual(strip_html_tags('foo&#x2764;bar'), 'foo❤bar')
+        self.assertEqual(strip_html_tags('   foo    '), 'foo')
+        self.assertEqual(strip_html_tags('  foo  bar  '), 'foo bar')
+        self.assertEqual(strip_html_tags('<!-- no --> <x>foo<y>bar'), 'foobar')
+        self.assertEqual(strip_html_tags('<p>1 &lt; 2</p>'), '1 < 2')
+        self.assertEqual(strip_html_tags('<script'), '')
+
+    def test_non_string_raises(self):
+        with typeguard.suppress_type_checks(), self.assertRaises(AssertionError):
+            strip_html_tags(None)
+        with typeguard.suppress_type_checks(), self.assertRaises(AssertionError):
+            strip_html_tags(42)
+
+    def test_double_execution_loop(self):
+        # HTMLParser misses tags on first pass (e.g. inside <style> blocks)
+        test_code = '1&amp;2</p><style><!-- removed in second run --></style>'
+
+        first_run = _strip_html_once(test_code, keep_paragraphs=True)
+        self.assertEqual(first_run, '1&2\n<!-- removed in second run -->')
+
+        second_run = _strip_html_once(first_run, keep_paragraphs=True)
+        self.assertEqual(second_run, '1&2')
+
+        self.assertEqual(strip_html_tags(test_code, keep_paragraphs=True), '1&2')
+
+    def test_paragraphs(self):
+        self.assertEqual(strip_html_tags(' \n foo \n bar \n ', keep_paragraphs=True), 'foo\nbar')
+        self.assertEqual(strip_html_tags(' \n foo \n bar \n ', keep_paragraphs=False), 'foo bar')
+
+        self.assertEqual(
+            strip_html_tags(' \t\r\f\v\n foo \t\r\f\v\n bar \t\r\f\v\n ', keep_paragraphs=True),
+            'foo\nbar',
+        )
+        self.assertEqual(
+            strip_html_tags(' \t\r\f\v\n foo \t\r\f\v\n bar \t\r\f\v\n ', keep_paragraphs=False),
+            'foo bar',
+        )
+
+        self.assertEqual(strip_html_tags(' \n\n foo \n\n bar \n\n ', keep_paragraphs=True), 'foo\n\nbar')
+        self.assertEqual(strip_html_tags(' \n\n foo \n\n bar \n\n ', keep_paragraphs=False), 'foo bar')
+
+        self.assertEqual(strip_html_tags('<p>foo</p><p>bar</p>', keep_paragraphs=True), 'foo\nbar')
+        self.assertEqual(strip_html_tags('\n<p>foo</p>\n<p>bar</p>\n', keep_paragraphs=True), 'foo\n\nbar')
+        self.assertEqual(strip_html_tags('<p>foo</p><p>bar</p>', keep_paragraphs=False), 'foo bar')
+        self.assertEqual(
+            strip_html_tags('<p>foo\n</p><p>\n</p><p>bar\n</p>', keep_paragraphs=False),
+            'foo bar',
+        )
+
+    def test_li_bullet(self):
+        self.assertEqual(strip_html_tags('<ul><li>a</li><li>b</li></ul>'), '· a · b')
+
+
+class Html2TextTests(TestCase):
+    def test_basic_paragraphs(self):
+        self.assertEqual(html2text('foo\nbar\n'), 'foo bar')
+        self.assertEqual(html2text('line1\n\nline2\n'), 'line1\n\nline2')
+        self.assertEqual(html2text('line1\r\n\r\nline2\r\n'), 'line1\n\nline2')
+        self.assertEqual(html2text('line1\r\rline2\r'), 'line1\n\nline2')
+        self.assertEqual(html2text('foo\n\n\nbar\n'), 'foo\n\nbar')
+        self.assertEqual(html2text('foo\n\n\n\nbar\n'), 'foo\n\nbar')
+
+    def test_p_tags(self):
+        self.assertEqual(html2text('<p>foo</p><p>bar</p>'), 'foo bar')
+        self.assertEqual(html2text('<p>foo</p><p></p><p>bar</p>'), 'foo\n\nbar')
+
+    def test_multiline_html(self):
+        value = '<p>intro sentence<p>\n\n<p><p>\n\n<p>description\nfoo\n\t\r\n\f\v\n\nbar</p>\n\n\n'
+        self.assertEqual(html2text(value), 'intro sentence\n\ndescription foo\n\nbar')
+
+    def test_non_string_raises(self):
+        with typeguard.suppress_type_checks(), self.assertRaises(AssertionError):
+            html2text(None)


### PR DESCRIPTION
These stdlib-only HTML-to-plain-text helpers strip HTML tags from a string and convert HTML to plain text with paragraph breaks preserved. They rely only on Python's built-in `html.parser` and `bx_py_utils.string_utils.ensure_lf` — no lxml or BeautifulSoup needed. Useful for sanitising product descriptions, emails, or any user-facing text that may contain HTML markup.