### PR TITLE
enhance coverage / nox setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,21 @@ lint-fix: ## Check/fix code style by running: "ruff check --fix"
 	.venv/bin/ruff check --fix
 
 .PHONY: nox
-nox:  ## Run tests via nox with all environments
-	.venv/bin/nox
+nox:  ## Run tests via nox with all environments and create coverage report
+	uv run nox
+	$(MAKE) coverage-report
+
+.PHONY: coverage-report
+coverage-report:  ## Creates coverage report
+	uv run coverage combine --append
+	uv run coverage report
+	uv run coverage xml
+	uv run coverage json
+
+.PHONY: coverage
+coverage:  ## Run tests with coverage (Use better "nox" target)
+	uv run coverage run
+	$(MAKE) coverage-report
 
 .PHONY: test
 test: ## Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ parallel = true
 source = ['.']
 concurrency = ["multiprocessing"]
 command_line = "-m unittest --locals --verbose"
+data_file = ".coverage_data/.coverage"
 
 [tool.coverage.report]
 omit = ['.*', '*/tests/*']


### PR DESCRIPTION
Move coverage data files into `.coverage_data`, so they doesn't lay in the project root directory. This is also better, if a "nox" run failes and many obsolete coverage data files are still there.

Because the directory starts with `.` it's already hidden by gitignore.

Add also a few make targets around coverage run/report. The same as in bx_django_utils.